### PR TITLE
[Feat] accessToken 생성 시 Roletype 추가 

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -1,12 +1,13 @@
 package com.souf.soufwebsite.domain.member.service;
 
+import com.souf.soufwebsite.domain.member.dto.*;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.ResetReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.SigninReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.SignupReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.UpdateReqDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.UserResDto;
-import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import com.souf.soufwebsite.domain.member.entity.Member;
+import com.souf.soufwebsite.domain.member.entity.RoleType;
 import com.souf.soufwebsite.domain.member.reposiotry.MemberRepository;
 import com.souf.soufwebsite.global.email.EmailService;
 import com.souf.soufwebsite.global.jwt.JwtService;
@@ -61,9 +62,12 @@ public class MemberServiceImpl implements MemberService {
 
         Authentication authentication = authenticationManager.authenticate(token);
         String email = authentication.getName();
-        System.out.println("email = " + email);
 
-        String accessToken = jwtService.createAccessToken(email);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        RoleType role = member.getRole();
+
+        String accessToken = jwtService.createAccessToken(email, role);
         String refreshToken = jwtService.createRefreshToken(email);
 
         redisTemplate.opsForValue().set("refresh:" + email, refreshToken, jwtService.getExpiration(refreshToken), TimeUnit.MILLISECONDS);

--- a/src/main/java/com/souf/soufwebsite/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/souf/soufwebsite/global/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.souf.soufwebsite.global.jwt;
 
+import com.souf.soufwebsite.domain.member.entity.Member;
+import com.souf.soufwebsite.domain.member.entity.RoleType;
 import com.souf.soufwebsite.domain.member.reposiotry.MemberRepository;
 import com.souf.soufwebsite.global.security.UserDetailsImpl;
 import jakarta.servlet.FilterChain;
@@ -14,7 +16,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -119,7 +120,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String storedRefreshToken = redisTemplate.opsForValue().get("refresh:" + email);
         if (refreshToken.equals(storedRefreshToken)) {
-            String newAccessToken = jwtService.createAccessToken(email);
+            RoleType role = memberRepository.findByEmail(email)
+                    .map(Member::getRole)
+                    .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+
+            String newAccessToken = jwtService.createAccessToken(email, role);
             log.info("AccessToken 재발급: {}", newAccessToken);
             return newAccessToken;
         }

--- a/src/main/java/com/souf/soufwebsite/global/jwt/JwtService.java
+++ b/src/main/java/com/souf/soufwebsite/global/jwt/JwtService.java
@@ -1,5 +1,6 @@
 package com.souf.soufwebsite.global.jwt;
 
+import com.souf.soufwebsite.domain.member.entity.RoleType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -7,7 +8,7 @@ import java.util.Optional;
 
 public interface JwtService {
 
-    String createAccessToken(String email);
+    String createAccessToken(String email, RoleType role);
 
     String createRefreshToken(String email);
 

--- a/src/main/java/com/souf/soufwebsite/global/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/global/jwt/JwtServiceImpl.java
@@ -1,5 +1,6 @@
 package com.souf.soufwebsite.global.jwt;
 
+import com.souf.soufwebsite.domain.member.entity.RoleType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -41,11 +42,12 @@ public class JwtServiceImpl implements JwtService {
     }
 
     @Override
-    public String createAccessToken(String email) {
+    public String createAccessToken(String email, RoleType role) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + accessTokenExpireTime);
         return Jwts.builder()
                 .setSubject(email)
+                .claim("role", role.name())
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)
                 .signWith(secretKey, SignatureAlgorithm.HS256)

--- a/src/main/java/com/souf/soufwebsite/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/souf/soufwebsite/global/security/UserDetailsImpl.java
@@ -2,6 +2,7 @@ package com.souf.soufwebsite.global.security;
 
 import com.souf.soufwebsite.domain.member.entity.Member;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -17,7 +18,8 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        String roleName = "ROLE_" + member.getRole().name();
+        return List.of(new SimpleGrantedAuthority(roleName));
     }
 
     @Override


### PR DESCRIPTION
## 개요
AccessToken 생성 시 claim에 user의 RoleType 정보를 추가했습니다.

## 진행한 이슈
- close #40 

## 구현 내용
- ![image](https://github.com/user-attachments/assets/8ceb714c-14b0-4385-905a-04cf66a9d51b)

## 참고 자료
- 로그인 시 생성되는 accessToken 을 디코딩하여 RoleType 정보가 출력되는 것을 확인했습니다.
- 아직 권한 별 접근 가능한 api가 분리되어 있지 않기 때문에 추후 분리할 필요가 있습니다.
