### PR TITLE
[Fix] 피드공고문 api swagger 적용

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
@@ -1,0 +1,57 @@
+package com.souf.soufwebsite.domain.feed.controller;
+
+import com.souf.soufwebsite.domain.feed.dto.FeedDetailResDto;
+import com.souf.soufwebsite.domain.feed.dto.FeedReqDto;
+import com.souf.soufwebsite.domain.feed.dto.FeedResDto;
+import com.souf.soufwebsite.domain.feed.dto.FeedSimpleResDto;
+import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
+import com.souf.soufwebsite.global.success.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+public interface FeedApiSpecification {
+
+    @Tag(name = "Feed", description = "피드 관련 API")
+    @Operation(summary = "피드 생성", description = "학생 권한을 가진 사용자가 피드를 생성합니다.")
+    @PostMapping
+    SuccessResponse<FeedResDto> createFeed(
+            @RequestBody @Valid FeedReqDto feedReqDto);
+
+    @Tag(name = "Feed", description = "피드 관련 API")
+    @Operation(summary = "해당 피드 관련 미디어 파일 정보 저장", description = "제공된 presignedUrl을 통해 업로드한 파일의 정보를 DB에도 반영할 수 있도록 서버에게 파일 정보를 보냅니다.")
+    @PostMapping("/upload")
+    SuccessResponse uploadMetadata(@Valid @RequestBody MediaReqDto mediaReqDto);
+
+    @Tag(name = "Feed", description = "피드 관련 API")
+    @Operation(summary = "피드 리스트 조회", description = "특정 학생이 올린 피드 리스트들을 조회합니다.")
+    @GetMapping("/{memberId}")
+    SuccessResponse<Page<FeedSimpleResDto>> getFeeds(
+            @PathVariable(name = "memberId") Long memberId,
+            @PageableDefault(size = 12) Pageable pageable);
+
+    @Tag(name = "Feed", description = "학생 피드 관련 API")
+    @Operation(summary = "특정 피드 상세 조회", description = "특정 피드에 대한 상세 정보를 조회합니다.")
+    @GetMapping("/{memberId}/{feedId}")
+    SuccessResponse<FeedDetailResDto> getFeed(
+            @PathVariable(name = "memberId") Long memberId,
+            @PathVariable(name = "feedId") Long feedId);
+
+    @Tag(name = "Feed", description = "학생 피드 관련 API")
+    @Operation(summary = "특정 피드 수정", description = "사용자 본인이 소유한 피드에 대해 수정합니다.")
+    @PatchMapping("/{feedId}")
+    SuccessResponse<FeedResDto> updateFeed(
+            @PathVariable(name = "feedId") Long feedId,
+            @RequestBody @Valid FeedReqDto reqDto);
+
+    @Tag(name = "Feed", description = "학생 피드 관련 API")
+    @Operation(summary = "특정 피드 삭제", description = "사용자 본인이 소유한 피드를 삭제합니다.")
+    @DeleteMapping("/{feedId}")
+    SuccessResponse<?> deleteFeed(@PathVariable(name = "feedId") Long feedId);
+
+
+}

--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
@@ -19,7 +19,7 @@ import static com.souf.soufwebsite.domain.recruit.controller.RecruitSuccessMessa
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/feed")
-public class FeedController {
+public class FeedController implements FeedApiSpecification{
 
     private final FeedService feedService;
 

--- a/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedReqDto.java
@@ -1,5 +1,6 @@
 package com.souf.soufwebsite.domain.feed.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -7,12 +8,18 @@ import java.util.List;
 
 public record FeedReqDto(
 
+        @Schema(description = "제목", example = "봄 프로젝트 1회차")
         @NotEmpty
         String topic,
 
+        @Schema(description = "피드 내용", example = "오늘 작업 내용...")
         @NotNull
         String content,
+
+        @Schema(description = "해시 태그", example = "[봄, 산책, 나들이, 어린이 대공원]('#'는 빼고 보내주세요!")
         List<String> tags,
+
+        @Schema(description = "원본 파일 이름", example = "[fileName.jpg, dog.jpg..]")
         List<String> originalFileNames
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaReqDto.java
@@ -1,11 +1,20 @@
 package com.souf.soufwebsite.domain.file.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record MediaReqDto(
+        @Schema(description = "해당 공고문/피드의 아이디", example = "1")
         Long postId,
+
+        @Schema(description = "해당 파일에 접근할 수 있는 url", example = "[s3://sjekfjla.., s3://sfefnk, s3://asfe, s3://fweop]" )
         List<String> fileUrl,
+
+        @Schema(description = "해당 공고문/피드의 원래 파일 이름", example = "[fileName, pictureName, spring, hihi]")
         List<String> fileName,
-        List<String> fileType // IMAGE, VIDEO 등
+
+        @Schema(description = "해당 공고문/피드의 아이디", example = "[jpg, jpg, png, jpeg]")
+        List<String> fileType
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
@@ -1,0 +1,49 @@
+package com.souf.soufwebsite.domain.recruit.controller;
+
+import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
+import com.souf.soufwebsite.domain.recruit.dto.RecruitCreateResDto;
+import com.souf.soufwebsite.domain.recruit.dto.RecruitReqDto;
+import com.souf.soufwebsite.domain.recruit.dto.RecruitResDto;
+import com.souf.soufwebsite.domain.recruit.dto.RecruitSimpleResDto;
+import com.souf.soufwebsite.global.success.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+public interface RecruitApiSpecification {
+
+    @Tag(name = "Recruit", description = "공고문 관련 API")
+    @Operation(summary = "공고문 생성", description = "일반 사용자의 권한을 가진 사용자가 공고문을 생성합니다.")
+    @PostMapping
+    SuccessResponse<RecruitCreateResDto> createRecruit(@Valid @RequestBody RecruitReqDto recruitReqDto);
+
+    @Tag(name = "Recruit", description = "공고문 관련 API")
+    @Operation(summary = "해당 공고문 관련 미디어 파일 정보 저장", description = "제공된 presignedUrl을 통해 업로드한 파일의 정보를 DB에도 반영할 수 있도록 서버에게 파일 정보를 보냅니다.")
+    @PostMapping("/upload")
+    SuccessResponse uploadMetadata(@Valid @RequestBody MediaReqDto mediaReqDto);
+
+    @Tag(name = "Recruit", description = "공고문 관련 API")
+    @Operation(summary = "공고문 리스트 조회", description = "카테고리에 걸맞는 공고문 리스트를 조회합니다.")
+    @GetMapping
+    SuccessResponse<List<RecruitSimpleResDto>> getRecruits(@RequestParam(name = "firstCategory") Long first,
+                                                                  @RequestParam(name = "secondCategory") Long second,
+                                                                  @RequestParam(name = "thirdCategory") Long third);
+
+    @Tag(name = "Recruit", description = "공고문 관련 API")
+    @Operation(summary = "특정 공고문 상세 조회", description = "특정 공고문에 대한 상세 정보를 조회합니다.")
+    @GetMapping("/{recruitId}")
+    SuccessResponse<RecruitResDto> getRecruitById(@PathVariable(name = "recruitId") Long recruitId);
+
+    @Tag(name = "Recruit", description = "공고문 관련 API")
+    @Operation(summary = "특정 공고문 수정", description = "사용자 본인이 소유한 공고문에 대해 수정합니다.")
+    @PatchMapping("/{recruitId}")
+    SuccessResponse updateRecruit(@PathVariable(name = "recruitId") Long recruitId, @Valid @RequestBody RecruitReqDto recruitReqDto);
+
+    @Tag(name = "Recruit", description = "공고문 관련 API")
+    @Operation(summary = "특정 공고문 삭제", description = "사용자 본인이 소유한 공고문에 대해 삭제합니다.")
+    @DeleteMapping("/{recruitId}")
+    SuccessResponse deleteRecruit(@PathVariable(name = "recruitId") Long recruitId);
+}

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
@@ -18,7 +18,7 @@ import static com.souf.soufwebsite.domain.recruit.controller.RecruitSuccessMessa
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/recruit")
-public class RecruitController {
+public class RecruitController implements RecruitApiSpecification{
 
     private final RecruitService recruitService;
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/RecruitReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/RecruitReqDto.java
@@ -2,6 +2,7 @@ package com.souf.soufwebsite.domain.recruit.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -11,31 +12,41 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record RecruitReqDto(
+        @Schema(description = "공고문 제목", example = "[SW] ggott sw 개발자 모집")
         @NotEmpty(message = "공고문 제목은 필수입니다.")
         @Size(min = 2)
         String title,
+
+        @Schema(description = "공고문 내용", example = "공고문 내용...")
         @NotNull(message = "공고문 내용은 필수입니다.")
         @Size(max = 300)
         String content,
+
+        @Schema(description = "지역", example = "광진구 화양동")
         @NotNull(message = "진행 지역은 필수입니다.")
         @Size(max = 30)
         String region,
 
+        @Schema(description = "마감 기한", example = "2025-06-23T13:29")
         @Future
         @NotNull(message = "마감 기한은 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
         LocalDateTime deadline,
 
+        @Schema(description = "제시 금액", example = "100만원")
         @NotEmpty(message = "제시 금액은 필수입니다.")
         String payment,
 
+        @Schema(description = "우대사항", example = "1. 전공자 우대\n2. 군필자 우대\n3. Powerpoint를 다루어 본 자")
         @NotNull(message = "우대사항은 옵션입니다.")
         @Size(max = 300)
         String preferentialTreatment,
 
+        @Schema(description = "카테고리 목록", implementation = CategoryDto.class)
         @NotNull(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
         List<CategoryDto> categoryDtos,
 
+        @Schema(description = "원본 파일 이름", example = "[fileName.jpg, dog.jpg..]")
         List<String> originalFileNames
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/global/common/category/dto/CategoryDto.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/category/dto/CategoryDto.java
@@ -1,8 +1,13 @@
 package com.souf.soufwebsite.global.common.category.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record CategoryDto(
+        @Schema(description = "1차 카테고리 ID", example = "10")
         Long firstCategory,
+        @Schema(description = "2차 카테고리 ID", example = "23")
         Long secondCategory,
+        @Schema(description = "3차 카테고리 ID", example = "57")
         Long thirdCategory) {
 
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
공고문/피드 API에 관한 swagger 추가

## 진행한 이슈
- close #45 

## 구현 내용
- [x] 이슈에 기입된 사항들을 모두 충족했나요?
- 상세히 구현한 내용들을 기입해 주세요!
1. 공고문/피드 API 및 ReqDto swagger 정보 추가

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
- 자바의 객체지향 특성을 이용하여 controller에 관한 interface에 swagger 어노테이션을 사용
![image](https://github.com/user-attachments/assets/72703837-bd58-4d75-aeb8-9976fec72163)
![image](https://github.com/user-attachments/assets/899edd99-0f81-43ff-bbc5-aa7d3d8ec736)
