### PR TITLE
[Fix] 회원가입/회원정보수정 로직 수정

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/application/controller/RecruitApplicationApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/application/controller/RecruitApplicationApiSpecification.java
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
+@Tag(name = "Application", description = "지원 관련 API")
 public interface RecruitApplicationApiSpecification {
-    @Tag(name = "Application", description = "지원 관련 API")
     @Operation(summary = "특정 공고문 지원자 리스트 조회", description = "특정 공고문에 지원한 지원자들의 리스트를 조회합니다.")
     @GetMapping("/{recruitId}/applicants")
     SuccessResponse<Page<ApplicantResDto>> getApplicantsForRecruit(
@@ -20,12 +20,10 @@ public interface RecruitApplicationApiSpecification {
             @PageableDefault(size = 10) Pageable pageable
     );
 
-    @Tag(name = "Application", description = "지원 관련 API")
     @Operation(summary = "지원 승인", description = "특정 지원자의 지원을 승인합니다.")
     @PostMapping("/{applicationId}/approve")
     SuccessResponse<?> reviewApplication(@PathVariable Long applicationId);
 
-    @Tag(name = "Application", description = "지원 관련 API")
     @Operation(summary = "지원 거절", description = "특정 지원자의 지원을 거절합니다.")
     @PostMapping("/{applicationId}/reject")
     SuccessResponse<?> rejectApplication(@PathVariable Long applicationId);

--- a/src/main/java/com/souf/soufwebsite/domain/application/controller/StudentApplicationApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/application/controller/StudentApplicationApiSpecification.java
@@ -12,19 +12,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
+@Tag(name = "Application", description = "지원 관련 API")
 public interface StudentApplicationApiSpecification {
 
-    @Tag(name = "Application", description = "지원 관련 API")
     @Operation(summary = "지원하기", description = "특정 공고문에 지원합니다.")
     @PostMapping("/{recruitId}/apply")
     SuccessResponse<?> apply(@PathVariable Long recruitId);
 
-    @Tag(name = "Application", description = "지원 관련 API")
     @Operation(summary = "지원 취소", description = "특정 공고문에 대한 지원을 취소합니다.")
     @DeleteMapping("/{recruitId}/apply")
     SuccessResponse<?> deleteApplication(@PathVariable Long recruitId);
 
-    @Tag(name = "Application", description = "지원 관련 API")
     @Operation(summary = "내 지원 리스트 조회", description = "사용자 본인이 지원한 공고문 리스트를 조회합니다.")
     @GetMapping("/my")
     SuccessResponse<Page<MyApplicationResDto>> getMyApplications(@PageableDefault(size = 10) Pageable pageable);

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
@@ -15,46 +15,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Member", description = "회원 관련 API")
-@RequestMapping("/api/v1")
+@Tag(name = "회원", description = "회원 정보 관련 API")
+@RequestMapping("/api/v1/member")
 public interface MemberApiSpecification {
-
-    @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다.")
-    @PostMapping("/auth/signup")
-    SuccessResponse<?> signup(
-            @RequestBody @Valid SignupReqDto reqDto
-    );
-
-    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 토큰을 발급받습니다.")
-    @PostMapping("/auth/login")
-    SuccessResponse<TokenDto> signin(
-            @RequestBody @Valid SigninReqDto reqDto
-    );
-
-    @Operation(summary = "비밀번호 재설정", description = "입력한 새 비밀번호로 계정 비밀번호를 변경합니다.")
-    @PatchMapping("/auth/reset/password")
-    SuccessResponse<?> resetPassword(
-            @RequestBody @Valid ResetReqDto reqDto
-    );
-
-    @Operation(summary = "이메일 인증번호 전송", description = "입력된 이메일로 인증번호를 전송합니다.")
-    @PostMapping("/auth/email/send")
-    SuccessResponse<Boolean> sendEmailVerification(
-            @RequestParam String email
-    );
-
-    @Operation(summary = "이메일 인증번호 검증", description = "이메일로 발급된 인증번호와 일치하게 입력하였는지 검증합니다.")
-    @PostMapping("/auth/email/verify")
-    SuccessResponse<Boolean> verifyEmailCode(
-            @RequestParam String email,
-            @RequestParam String code
-    );
-
-    @Operation(summary = "회원정보 수정", description = "로그인된 사용자의 회원정보를 업데이트합니다.")
-    @PutMapping("/auth/update")
-    SuccessResponse<?> updateUserInfo(
-            @RequestBody @Valid UpdateReqDto reqDto
-    );
 
     @Operation(summary = "회원 목록 조회", description = "모든 회원의 정보를 페이징하여 조회합니다.")
     @GetMapping("/member")
@@ -87,4 +50,9 @@ public interface MemberApiSpecification {
             Pageable pageable
     );
 
+    @Operation(summary = "회원정보 수정", description = "로그인된 사용자의 회원정보를 업데이트합니다.")
+    @PutMapping("/update")
+    SuccessResponse<?> updateUserInfo(
+            @RequestBody @Valid UpdateReqDto reqDto
+    );
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
@@ -21,64 +21,25 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/member")
 @Slf4j
-public class MemberController implements MemberApiSpecification {
+public class MemberController implements MemberApiSpecification{
 
     private final MemberService memberService;
 
-    @PostMapping("/auth/signup")
-    public SuccessResponse<?> signup(@RequestBody @Valid SignupReqDto reqDto) {
-        memberService.signup(reqDto);
-        return new SuccessResponse<>("회원가입 성공");
-    }
-
-    @PostMapping("/auth/login")
-    public SuccessResponse<TokenDto> signin(@RequestBody @Valid SigninReqDto reqDto) {
-        log.info("로그인 요청: {}", reqDto);
-        TokenDto tokenDto = memberService.signin(reqDto);
-        log.info("로그인 성공: {}", tokenDto);
-        return new SuccessResponse<>(tokenDto);
-    }
-
-    @PatchMapping("/auth/reset/password")
-    public SuccessResponse<?> resetPassword(@RequestBody ResetReqDto reqDto) {
-        memberService.resetPassword(reqDto);
-        return new SuccessResponse<>("비밀번호 재설정 성공");
-    }
-
-    // 인증번호 전송
-    @PostMapping("/auth/email/send")
-    public SuccessResponse<Boolean> sendEmailVerification(@RequestParam String email) {
-        return new SuccessResponse<>(memberService.sendEmailVerification(email));
-    }
-
-    // 인증번호 검증
-    @PostMapping("/auth/email/verify")
-    public SuccessResponse<Boolean> verifyEmailCode(@RequestParam String email, @RequestParam String code) {
-        boolean verified = memberService.verifyEmail(email, code);
-        return new SuccessResponse<>(verified);
-    }
-
-    @PutMapping("/auth/update")
-    public SuccessResponse<?> updateUserInfo(@RequestBody UpdateReqDto reqDto) {
-        memberService.updateUserInfo(reqDto);
-        return new SuccessResponse<>("회원정보 수정 성공");
-    }
-
-    @GetMapping("/member")
+    @GetMapping
     public SuccessResponse<Page<MemberResDto>> getMembers(
             @PageableDefault(size = 6) Pageable pageable
     ) {
         return new SuccessResponse<>(memberService.getMembers(pageable));
     }
 
-    @GetMapping("/member/{id}")
+    @GetMapping("/{id}")
     public SuccessResponse<MemberResDto> getMemberById(@PathVariable Long id) {
         return new SuccessResponse<>(memberService.getMemberById(id));
     }
 
-    @GetMapping("/member/search")
+    @GetMapping("/search")
     public SuccessResponse<Page<MemberResDto>> findByCategory(
             @RequestParam(required = false) Long first,
             @RequestParam(required = false) Long second,
@@ -91,7 +52,7 @@ public class MemberController implements MemberApiSpecification {
         );
     }
 
-    @GetMapping("/member/search/nickname")
+    @GetMapping("/search/nickname")
     public SuccessResponse<Page<MemberResDto>> findByNickname(
             @RequestParam String keyword,
             @PageableDefault(size = 6) Pageable pageable
@@ -102,10 +63,9 @@ public class MemberController implements MemberApiSpecification {
         );
     }
 
-    @GetMapping("/member/nickname/available")
-    public SuccessResponse<Boolean> isNicknameAvailable(
-            @RequestParam @NotEmpty String nickname) {
-        boolean available = memberService.isNicknameAvailable(nickname);
-        return new SuccessResponse<>(available, "닉네임 사용 가능 여부");
+    @PutMapping("/update")
+    public SuccessResponse<?> updateUserInfo(@RequestBody UpdateReqDto reqDto) {
+        memberService.updateUserInfo(reqDto);
+        return new SuccessResponse<>("회원정보 수정 성공");
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -1,0 +1,55 @@
+package com.souf.soufwebsite.domain.member.controller.auth;
+
+import com.souf.soufwebsite.domain.member.dto.ReqDto.ResetReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.SigninReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.SignupReqDto;
+import com.souf.soufwebsite.domain.member.dto.TokenDto;
+import com.souf.soufwebsite.global.success.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "회원가입", description = "회원가입 관련 API")
+@RequestMapping("/api/v1/auth")
+public interface AuthApiSpecification {
+
+    @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다.")
+    @PostMapping("/signup")
+    SuccessResponse<?> signup(
+            @RequestBody @Valid SignupReqDto reqDto
+    );
+
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 토큰을 발급받습니다.")
+    @PostMapping("/login")
+    SuccessResponse<TokenDto> signin(
+            @RequestBody @Valid SigninReqDto reqDto
+    );
+
+    @Operation(summary = "비밀번호 재설정", description = "입력한 새 비밀번호로 계정 비밀번호를 변경합니다.")
+    @PatchMapping("/reset/password")
+    SuccessResponse<?> resetPassword(
+            @RequestBody @Valid ResetReqDto reqDto
+    );
+
+    @Operation(summary = "이메일 인증번호 전송", description = "입력된 이메일로 인증번호를 전송합니다.")
+    @PostMapping("/email/send")
+    SuccessResponse<Boolean> sendEmailVerification(
+            @RequestParam String email
+    );
+
+    @Operation(summary = "이메일 인증번호 검증", description = "이메일로 발급된 인증번호와 일치하게 입력하였는지 검증합니다.")
+    @PostMapping("/email/verify")
+    SuccessResponse<Boolean> verifyEmailCode(
+            @RequestParam String email,
+            @RequestParam String code
+    );
+
+    @Operation(summary = "닉네임 중복 검증", description = "입력된 닉네임이 사용 가능한지 확인합니다.")
+    @GetMapping("/nickname/available")
+    SuccessResponse<Boolean> isNicknameAvailable(
+            @RequestParam @NotEmpty String nickname
+    );
+
+}

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
@@ -1,0 +1,62 @@
+package com.souf.soufwebsite.domain.member.controller.auth;
+
+import com.souf.soufwebsite.domain.member.dto.ReqDto.ResetReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.SigninReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.SignupReqDto;
+import com.souf.soufwebsite.domain.member.dto.TokenDto;
+import com.souf.soufwebsite.domain.member.service.MemberService;
+import com.souf.soufwebsite.global.success.SuccessResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+@Slf4j
+public class AuthController {
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public SuccessResponse<?> signup(@RequestBody @Valid SignupReqDto reqDto) {
+        memberService.signup(reqDto);
+        return new SuccessResponse<>("회원가입 성공");
+    }
+
+    @PostMapping("/login")
+    public SuccessResponse<TokenDto> signin(@RequestBody @Valid SigninReqDto reqDto) {
+        log.info("로그인 요청: {}", reqDto);
+        TokenDto tokenDto = memberService.signin(reqDto);
+        log.info("로그인 성공: {}", tokenDto);
+        return new SuccessResponse<>(tokenDto);
+    }
+
+    @PatchMapping("/reset/password")
+    public SuccessResponse<?> resetPassword(@RequestBody ResetReqDto reqDto) {
+        memberService.resetPassword(reqDto);
+        return new SuccessResponse<>("비밀번호 재설정 성공");
+    }
+
+    // 인증번호 전송
+    @PostMapping("/email/send")
+    public SuccessResponse<Boolean> sendEmailVerification(@RequestParam String email) {
+        return new SuccessResponse<>(memberService.sendEmailVerification(email));
+    }
+
+    // 인증번호 검증
+    @PostMapping("/email/verify")
+    public SuccessResponse<Boolean> verifyEmailCode(@RequestParam String email, @RequestParam String code) {
+        boolean verified = memberService.verifyEmail(email, code);
+        return new SuccessResponse<>(verified);
+    }
+
+    // 이메일 중복 검증
+    @GetMapping("/nickname/available")
+    public SuccessResponse<Boolean> isNicknameAvailable(
+            @RequestParam @NotEmpty String nickname) {
+        boolean available = memberService.isNicknameAvailable(nickname);
+        return new SuccessResponse<>(available, "닉네임 사용 가능 여부");
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategoryApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategoryApiSpecification.java
@@ -1,10 +1,9 @@
-package com.souf.soufwebsite.domain.member.controller;
+package com.souf.soufwebsite.domain.member.controller.memberCategory;
 
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
 import com.souf.soufwebsite.global.common.category.dto.UpdateReqDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategoryApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategoryApiSpecification.java
@@ -1,7 +1,7 @@
 package com.souf.soufwebsite.domain.member.controller.memberCategory;
 
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
-import com.souf.soufwebsite.global.common.category.dto.UpdateReqDto;
+import com.souf.soufwebsite.global.common.category.dto.CategoryUpdateReqDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,7 +31,7 @@ public interface MemberCategoryApiSpecification {
     @PutMapping("/{memberId}")
     SuccessResponse<?> updateCategory(
             @PathVariable Long memberId,
-            @Valid @RequestBody UpdateReqDto dto
+            @Valid @RequestBody CategoryUpdateReqDto dto
     );
 
     @Operation(summary = "카테고리 목록 조회", description = "회원이 설정한 카테고리 목록을 조회합니다.")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategoryController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategoryController.java
@@ -1,4 +1,4 @@
-package com.souf.soufwebsite.domain.member.controller;
+package com.souf.soufwebsite.domain.member.controller.memberCategory;
 
 import com.souf.soufwebsite.domain.member.service.MemberCategoryService;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import static com.souf.soufwebsite.domain.member.controller.MemberCategorySuccessMessage.*;
+import static com.souf.soufwebsite.domain.member.controller.memberCategory.MemberCategorySuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategoryController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategoryController.java
@@ -2,7 +2,7 @@ package com.souf.soufwebsite.domain.member.controller.memberCategory;
 
 import com.souf.soufwebsite.domain.member.service.MemberCategoryService;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
-import com.souf.soufwebsite.global.common.category.dto.UpdateReqDto;
+import com.souf.soufwebsite.global.common.category.dto.CategoryUpdateReqDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +32,7 @@ public class MemberCategoryController implements MemberCategoryApiSpecification{
     }
 
     @PutMapping("/{memberId}")
-    public SuccessResponse updateCategory(@PathVariable Long memberId, @Valid @RequestBody UpdateReqDto dto) {
+    public SuccessResponse updateCategory(@PathVariable Long memberId, @Valid @RequestBody CategoryUpdateReqDto dto) {
         memberCategoryService.updateCategory(memberId, dto.oldCategory(), dto.newCategory());
         return new SuccessResponse(CATEGORY_UPDATE_SUCCESS.getMessage());
     }

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategorySuccessMessage.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/memberCategory/MemberCategorySuccessMessage.java
@@ -1,4 +1,4 @@
-package com.souf.soufwebsite.domain.member.controller;
+package com.souf.soufwebsite.domain.member.controller.memberCategory;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/SignupReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/SignupReqDto.java
@@ -1,7 +1,10 @@
 package com.souf.soufwebsite.domain.member.dto.ReqDto;
 
+import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
+
+import java.util.List;
 
 public record SignupReqDto(
 
@@ -23,6 +26,9 @@ public record SignupReqDto(
         @NotEmpty String password,
 
         @Schema(description = "비밀번호 확인", example = "Passw0rd!")
-        @NotEmpty String passwordCheck
+        @NotEmpty String passwordCheck,
+
+        @Schema(description = "카테고리 목록", example = "[{\"firstCategory\": 1, \"secondCategory\": 1}, {\"thirdCategory\": 1}]")
+        List<CategoryDto> categoryDtos
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/UpdateReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/UpdateReqDto.java
@@ -1,6 +1,10 @@
 package com.souf.soufwebsite.domain.member.dto.ReqDto;
 
+import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
+import com.souf.soufwebsite.global.common.category.dto.CategoryUpdateReqDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
 
 public record UpdateReqDto(
 
@@ -14,6 +18,14 @@ public record UpdateReqDto(
         String intro,
 
         @Schema(description = "개인 URL", example = "https://github.com/username")
-        String personalUrl
+        String personalUrl,
+
+        @Schema(
+                description = "수정 전/후 카테고리 리스트",
+                implementation = CategoryUpdateReqDto.class,
+                example = "[{\"oldCategory\":{\"firstCategory\":1,\"secondCategory\":2,\"thirdCategory\":3},"
+                        + "\"newCategory\":{\"firstCategory\":4,\"secondCategory\":5,\"thirdCategory\":6}}]"
+        )
+        List<CategoryUpdateReqDto> categoryUpdates
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/UpdateReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/UpdateReqDto.java
@@ -1,7 +1,6 @@
 package com.souf.soufwebsite.domain.member.dto.ReqDto;
 
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
-import com.souf.soufwebsite.global.common.category.dto.CategoryUpdateReqDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -21,11 +20,10 @@ public record UpdateReqDto(
         String personalUrl,
 
         @Schema(
-                description = "수정 전/후 카테고리 리스트",
-                implementation = CategoryUpdateReqDto.class,
-                example = "[{\"oldCategory\":{\"firstCategory\":1,\"secondCategory\":2,\"thirdCategory\":3},"
-                        + "\"newCategory\":{\"firstCategory\":4,\"secondCategory\":5,\"thirdCategory\":6}}]"
+                description = "수정 후 카테고리 리스트",
+                implementation = CategoryDto.class,
+                example = "[{\"newCategory\":{\"firstCategory\":4,\"secondCategory\":5,\"thirdCategory\":6}}]"
         )
-        List<CategoryUpdateReqDto> categoryUpdates
+        List<CategoryDto> newCategories
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/UpdateReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/UpdateReqDto.java
@@ -22,7 +22,13 @@ public record UpdateReqDto(
         @Schema(
                 description = "수정 후 카테고리 리스트",
                 implementation = CategoryDto.class,
-                example = "[{\"newCategory\":{\"firstCategory\":4,\"secondCategory\":5,\"thirdCategory\":6}}]"
+                example = """
+        [
+          { "firstCategory": 1, "secondCategory": 1, "thirdCategory": 1 },
+          { "firstCategory": 1, "secondCategory": 1, "thirdCategory": 2 },
+          { "firstCategory": 1, "secondCategory": 1, "thirdCategory": 4 }
+        ]
+        """
         )
         List<CategoryDto> newCategories
 ) {

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
@@ -99,10 +99,9 @@ public class Member extends BaseEntity {
             }
         }
 
-        if (this.categories.size() >= 3) {
+        if (this.categories.size() > 3) {
             throw new NotExceedCategoryLimitException();
         }
-
         this.categories.add(mapping);
         mapping.setMember(this);
     }
@@ -118,5 +117,12 @@ public class Member extends BaseEntity {
                         mapping.getSecondCategory().getId().equals(dto.secondCategory()) &&
                         mapping.getThirdCategory().getId().equals(dto.thirdCategory())
         );
+    }
+
+    public void clearCategories() {
+        for (MemberCategoryMapping mapping : categories) {
+            mapping.disconnectMember();
+        }
+        categories.clear();
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
@@ -5,6 +5,8 @@ import com.souf.soufwebsite.domain.file.entity.Media;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.UpdateReqDto;
 import com.souf.soufwebsite.global.common.BaseEntity;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
+import com.souf.soufwebsite.global.common.category.exception.NotDuplicateCategoryException;
+import com.souf.soufwebsite.global.common.category.exception.NotExceedCategoryLimitException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
@@ -93,12 +95,12 @@ public class Member extends BaseEntity {
     public void addCategory(MemberCategoryMapping mapping) {
         for (MemberCategoryMapping existing : this.categories) {
             if (existing.isSameCategorySet(mapping)) {
-                throw new IllegalArgumentException("이미 존재하는 카테고리 세트입니다.");
+                throw new NotDuplicateCategoryException();
             }
         }
 
         if (this.categories.size() >= 3) {
-            throw new IllegalStateException("카테고리는 최대 3개까지만 등록할 수 있습니다.");
+            throw new NotExceedCategoryLimitException();
         }
 
         this.categories.add(mapping);

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/MemberCategoryMapping.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/MemberCategoryMapping.java
@@ -45,6 +45,9 @@ public class MemberCategoryMapping {
 
     public void setMember(Member member) {
         this.member = member;
-        member.getCategories().add(this);
+    }
+
+    public void disconnectMember() {
+        this.member = null;
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberCategoryServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberCategoryServiceImpl.java
@@ -5,6 +5,7 @@ import com.souf.soufwebsite.domain.member.entity.MemberCategoryMapping;
 import com.souf.soufwebsite.domain.member.exception.NotFoundMemberException;
 import com.souf.soufwebsite.domain.member.reposiotry.MemberCategoryMappingRepository;
 import com.souf.soufwebsite.domain.member.reposiotry.MemberRepository;
+import com.souf.soufwebsite.global.common.category.exception.NotFoundCategoryMappingException;
 import com.souf.soufwebsite.global.common.category.service.CategoryService;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
 import com.souf.soufwebsite.global.common.category.entity.FirstCategory;
@@ -60,6 +61,16 @@ public class MemberCategoryServiceImpl implements MemberCategoryService {
         SecondCategory second = categoryService.findIfSecondIdExists(newDto.secondCategory());
         ThirdCategory third = categoryService.findIfThirdIdExists(newDto.thirdCategory());
         categoryService.validate(first.getId(), second.getId(), third.getId());
+
+        boolean exists = member.getCategories().stream()
+                .anyMatch(mapping ->
+                        mapping.getFirstCategory().getId().equals(oldDto.firstCategory()) &&
+                                mapping.getSecondCategory().getId().equals(oldDto.secondCategory()) &&
+                                mapping.getThirdCategory().getId().equals(oldDto.thirdCategory())
+                );
+        if (!exists) {
+            throw new NotFoundCategoryMappingException();
+        }
 
         MemberCategoryMapping newMapping = MemberCategoryMapping.of(member, first, second, third);
         member.updateCategory(oldDto, newMapping);

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -96,8 +96,8 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(NotFoundMemberException::new);
         RoleType role = member.getRole();
 
-        String accessToken = jwtService.createAccessToken(email, role);
-        String refreshToken = jwtService.createRefreshToken(email);
+        String accessToken = jwtService.createAccessToken(member);
+        String refreshToken = jwtService.createRefreshToken(member);
 
         redisTemplate.opsForValue().set("refresh:" + email, refreshToken, jwtService.getExpiration(refreshToken), TimeUnit.MILLISECONDS);
 

--- a/src/main/java/com/souf/soufwebsite/global/common/category/dto/CategoryUpdateReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/category/dto/CategoryUpdateReqDto.java
@@ -2,7 +2,7 @@ package com.souf.soufwebsite.global.common.category.dto;
 
 import jakarta.validation.constraints.NotNull;
 
-public record UpdateReqDto(
+public record CategoryUpdateReqDto(
         @NotNull
         CategoryDto oldCategory,
         @NotNull

--- a/src/main/java/com/souf/soufwebsite/global/common/category/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/category/exception/ErrorType.java
@@ -14,9 +14,10 @@ public enum ErrorType {
 
     NOT_FOUND_FIRST_CATEGORY(404, "대분류 카테고리를 찾을 수 없습니다."),
     NOT_FOUND_SECOND_CATEGORY(404, "중분류 카테고리를 찾을 수 없습니다."),
-    NOT_FOUND_THIRD_CATEGORY(404, "소분류 카테고리를 찾을 수 없습니다.");
+    NOT_FOUND_THIRD_CATEGORY(404, "소분류 카테고리를 찾을 수 없습니다."),
 
-
+    NOT_DUPLICATE_CATEGORY(400, "이미 존재하는 카테고리입니다."),
+    NOT_EXCEED_CATEGORY_LIMIT(400, "카테고리는 최대 3개까지만 등록할 수 있습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/global/common/category/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/category/exception/ErrorType.java
@@ -17,6 +17,7 @@ public enum ErrorType {
     NOT_FOUND_THIRD_CATEGORY(404, "소분류 카테고리를 찾을 수 없습니다."),
 
     NOT_DUPLICATE_CATEGORY(400, "이미 존재하는 카테고리입니다."),
+    NOT_FOUND_CATEGORY_MAPPING(404, "카테고리를 찾을 수 없습니다."),
     NOT_EXCEED_CATEGORY_LIMIT(400, "카테고리는 최대 3개까지만 등록할 수 있습니다.");
 
     private final int code;

--- a/src/main/java/com/souf/soufwebsite/global/common/category/exception/NotDuplicateCategoryException.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/category/exception/NotDuplicateCategoryException.java
@@ -1,0 +1,11 @@
+package com.souf.soufwebsite.global.common.category.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.global.common.category.exception.ErrorType.NOT_DUPLICATE_CATEGORY;
+
+public class NotDuplicateCategoryException extends BaseErrorException {
+    public NotDuplicateCategoryException() {
+        super(NOT_DUPLICATE_CATEGORY.getCode(), NOT_DUPLICATE_CATEGORY.getMessage());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/global/common/category/exception/NotExceedCategoryLimitException.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/category/exception/NotExceedCategoryLimitException.java
@@ -1,0 +1,12 @@
+package com.souf.soufwebsite.global.common.category.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.global.common.category.exception.ErrorType.NOT_EXCEED_CATEGORY_LIMIT;
+
+public class NotExceedCategoryLimitException extends BaseErrorException {
+
+    public NotExceedCategoryLimitException() {
+        super(NOT_EXCEED_CATEGORY_LIMIT.getCode(), NOT_EXCEED_CATEGORY_LIMIT.getMessage());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/global/common/category/exception/NotFoundCategoryMappingException.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/category/exception/NotFoundCategoryMappingException.java
@@ -1,0 +1,11 @@
+package com.souf.soufwebsite.global.common.category.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.global.common.category.exception.ErrorType.NOT_FOUND_CATEGORY_MAPPING;
+
+public class NotFoundCategoryMappingException extends BaseErrorException {
+    public NotFoundCategoryMappingException() {
+        super(NOT_FOUND_CATEGORY_MAPPING.getCode(), NOT_FOUND_CATEGORY_MAPPING.getMessage());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/souf/soufwebsite/global/jwt/JwtAuthenticationFilter.java
@@ -120,11 +120,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String storedRefreshToken = redisTemplate.opsForValue().get("refresh:" + email);
         if (refreshToken.equals(storedRefreshToken)) {
-            RoleType role = memberRepository.findByEmail(email)
-                    .map(Member::getRole)
-                    .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+            Member member = memberRepository.findByEmail(email)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 회원을 찾을 수 없습니다."));
 
-            String newAccessToken = jwtService.createAccessToken(email, role);
+            String newAccessToken = jwtService.createAccessToken(member);
             log.info("AccessToken 재발급: {}", newAccessToken);
             return newAccessToken;
         }

--- a/src/main/java/com/souf/soufwebsite/global/jwt/JwtService.java
+++ b/src/main/java/com/souf/soufwebsite/global/jwt/JwtService.java
@@ -1,5 +1,6 @@
 package com.souf.soufwebsite.global.jwt;
 
+import com.souf.soufwebsite.domain.member.entity.Member;
 import com.souf.soufwebsite.domain.member.entity.RoleType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -8,9 +9,9 @@ import java.util.Optional;
 
 public interface JwtService {
 
-    String createAccessToken(String email, RoleType role);
+    String createAccessToken(Member member);
 
-    String createRefreshToken(String email);
+    String createRefreshToken(Member member);
 
 
     Optional<String> extractAccessToken(HttpServletRequest request);
@@ -18,8 +19,6 @@ public interface JwtService {
     Optional<String> extractRefreshToken(HttpServletRequest request);
 
     Optional<String> extractEmail(String accessToken);
-
-    Optional<RoleType> extractRoleType(String accessToken);
 
     boolean isTokenValid(String token);
 

--- a/src/main/java/com/souf/soufwebsite/global/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/global/jwt/JwtServiceImpl.java
@@ -1,5 +1,6 @@
 package com.souf.soufwebsite.global.jwt;
 
+import com.souf.soufwebsite.domain.member.entity.Member;
 import com.souf.soufwebsite.domain.member.entity.RoleType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -42,7 +43,10 @@ public class JwtServiceImpl implements JwtService {
     }
 
     @Override
-    public String createAccessToken(String email, RoleType role) {
+    public String createAccessToken(Member member) {
+        String email = member.getEmail();
+        RoleType role = member.getRole();
+
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + accessTokenExpireTime);
         return Jwts.builder()
@@ -55,7 +59,9 @@ public class JwtServiceImpl implements JwtService {
     }
 
     @Override
-    public String createRefreshToken(String email) {
+    public String createRefreshToken(Member member) {
+        String email = member.getEmail();
+
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + refreshTokenExpireTime);
         return Jwts.builder()
@@ -95,22 +101,6 @@ public class JwtServiceImpl implements JwtService {
             return Optional.ofNullable(claims.getSubject());
         } catch (JwtException e) {
             log.error("토큰에서 이메일 추출 실패: {}", e.getMessage());
-            return Optional.empty();
-        }
-    }
-
-    public Optional<RoleType> extractRoleType(String token) {
-        try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-
-            String role = claims.get("role", String.class);
-            return Optional.of(RoleType.valueOf(role));
-        } catch (Exception e) {
-            log.error("권한 추출 실패: {}", e.getMessage());
             return Optional.empty();
         }
     }


### PR DESCRIPTION
## 개요
- 회원가입에 카테고리 설정 로직을 추가합니다.
- 회원정보수정에 카테고리 수정 로직을 추가합니다.
- 멤버 컨트롤러를 각각의 기능에 맞게 분리합니다.

## 진행한 이슈
- close #54 

## 구현 내용
- ![image](https://github.com/user-attachments/assets/2c38859f-c2cc-455c-b6ae-c30be7c17a3d)
- ![image](https://github.com/user-attachments/assets/3db11acf-be42-4fba-9d07-20700b0b431c)
- ![image](https://github.com/user-attachments/assets/4e0dd5c4-2de6-4181-823e-641cdb0d5378)

## 참고 자료
