### PR TITLE
[FEAT] 이메일 인증 분리

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
@@ -32,8 +32,6 @@ public interface MemberApiSpecification {
     @GetMapping("/member/search")
     SuccessResponse<Page<MemberResDto>> findByCategory(
             @RequestParam(required = false) Long first,
-            @RequestParam(required = false) Long second,
-            @RequestParam(required = false) Long third,
             @PageableDefault(size = 6)
             Pageable pageable
     );

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
@@ -34,12 +34,10 @@ public class MemberController implements MemberApiSpecification{
     @GetMapping("/search")
     public SuccessResponse<Page<MemberResDto>> findByCategory(
             @RequestParam(required = false) Long first,
-            @RequestParam(required = false) Long second,
-            @RequestParam(required = false) Long third,
             @PageableDefault(size = 6) Pageable pageable
     ) {
         return new SuccessResponse<>(
-                memberService.getMembersByCategory(first, second, third, pageable),
+                memberService.getMembersByCategory(first, pageable),
                 "카테고리로 검색한 멤버 목록입니다."
         );
     }

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -33,9 +33,15 @@ public interface AuthApiSpecification {
             @RequestBody @Valid ResetReqDto reqDto
     );
 
-    @Operation(summary = "이메일 인증번호 전송", description = "입력된 이메일로 인증번호를 전송합니다.")
-    @PostMapping("/email/send")
-    SuccessResponse<Boolean> sendEmailVerification(
+    @Operation(summary = "이메일 인증번호 전송", description = "회원가입 시 입력된 이메일로 인증번호를 전송합니다.")
+    @PostMapping("/signup/email/send")
+    SuccessResponse<Boolean> sendSignupEmailVerification(
+            @RequestParam String email
+    );
+
+    @Operation(summary = "이메일 인증번호 전송", description = "비밀번호 재설정 시 입력된 이메일로 인증번호를 전송합니다.")
+    @PostMapping("/reset/email/send")
+    SuccessResponse<Boolean> sendResetEmailVerification(
             @RequestParam String email
     );
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
@@ -40,9 +40,14 @@ public class AuthController implements AuthApiSpecification{
     }
 
     // 인증번호 전송
-    @PostMapping("/email/send")
-    public SuccessResponse<Boolean> sendEmailVerification(@RequestParam String email) {
-        return new SuccessResponse<>(memberService.sendEmailVerification(email));
+    @PostMapping("/signup/email/send")
+    public SuccessResponse<Boolean> sendSignupEmailVerification(@RequestParam String email) {
+        return new SuccessResponse<>(memberService.sendSignupEmailVerification(email));
+    }
+
+    @PostMapping("/reset/email/send")
+    public SuccessResponse<Boolean> sendResetEmailVerification(@RequestParam String email) {
+        return new SuccessResponse<>(memberService.sendResetEmailVerification(email));
     }
 
     // 인증번호 검증

--- a/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberCustomRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberCustomRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MemberCustomRepository {
-    Page<Member> findByCategories(Long first, Long second, Long third, Pageable pageable);
+    Page<Member> findByCategory(Long first, Pageable pageable);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
     Page<Member> findByNicknameContainingIgnoreCase(String keyword, Pageable pageable);
 
     boolean existsByNickname(String nickname);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
@@ -16,7 +16,9 @@ public interface MemberService {
 
     void resetPassword(ResetReqDto reqDto);
 
-    boolean sendEmailVerification(String email);
+    boolean sendSignupEmailVerification(String email);
+
+    boolean sendResetEmailVerification(String email);
 
     boolean verifyEmail(String email, String code);
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
@@ -28,7 +28,7 @@ public interface MemberService {
 
     MemberResDto getMemberById(Long id);
 
-    Page<MemberResDto> getMembersByCategory(Long first, Long second, Long third, Pageable pageable);
+    Page<MemberResDto> getMembersByCategory(Long first, Pageable pageable);
 
     Page<MemberResDto> getMembersByNickname(String nickname, Pageable pageable);
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -196,8 +196,8 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public Page<MemberResDto> getMembersByCategory(Long first, Long second, Long third, Pageable pageable) {
-        Page<Member> result = memberRepository.findByCategories(first, second, third, pageable);
+    public Page<MemberResDto> getMembersByCategory(Long first, Pageable pageable) {
+        Page<Member> result = memberRepository.findByCategory(first, pageable);
         return result.map(MemberResDto::from);
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -41,7 +41,6 @@ public class MemberServiceImpl implements MemberService {
         return SecurityUtils.getCurrentMember();
     }
     private final CategoryService categoryService;
-    private final MemberCategoryService memberCategoryService;
 
     //회원가입
     @Override
@@ -113,11 +112,26 @@ public class MemberServiceImpl implements MemberService {
 
     //인증번호 전송
     @Override
-    public boolean sendEmailVerification(String email) {
-        String emailKey = "email:verification:" + email;
-        redisTemplate.delete(emailKey);
-        String code = String.format("%06d", new Random().nextInt(1000000));
+    public boolean sendSignupEmailVerification(String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new NotAvailableEmailException();
+        }
+        return sendEmailCode(email);
+    }
+
+    @Override
+    public boolean sendResetEmailVerification(String email) {
+        if (!memberRepository.existsByEmail(email)) {
+            throw new NotFoundMemberException();
+        }
+        return sendEmailCode(email);
+    }
+
+    private boolean sendEmailCode(String email) {
         String redisKey = "email:verification:" + email;
+
+        redisTemplate.delete(redisKey);
+        String code = String.format("%06d", new Random().nextInt(1000000));
         redisTemplate.opsForValue().set(redisKey, code, 5, TimeUnit.MINUTES);
 
         return emailService.sendEmail(email, "이메일 인증번호", "인증번호는 " + code + " 입니다.");


### PR DESCRIPTION
## 개요
이메일 인증번호 발송기능을 회원가입 / 비밀번호 재설정 에 따라 분리하였습니다.
카테고리에 따른 회원 검색 기능을 대분류만 사용하도록 수정하였습니다.

## 진행한 이슈
- close #58 

## 구현 내용
- ![image](https://github.com/user-attachments/assets/fdbfd798-40e8-415d-9468-01159d4b5a05)


