### PR TITLE
[FEAT] 유저 검색 필터링 및 프로필 이미지 설정 추가

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/repository/FeedRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRepository {
 
     Page<Feed> findAllByMemberOrderByIdDesc(Member member, Pageable pageable);
@@ -20,5 +22,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRep
     void increaseViewCount(@Param("feedId") Long feedId, @Param("count") Long count);
 
     Page<Feed> findByOrderByViewCountDesc(Pageable pageable);
+
+    List<Feed> findTop3ByMemberOrderByViewCountDesc(Member member);
 }
 

--- a/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaReqDto.java
@@ -8,7 +8,7 @@ public record MediaReqDto(
         @Schema(description = "해당 공고문/피드의 아이디", example = "1")
         Long postId,
 
-        @Schema(description = "해당 파일에 접근할 수 있는 url", example = "[s3://sjekfjla.., s3://sfefnk, s3://asfe, s3://fweop]" )
+        @Schema(description = "해당 파일에 접근할 수 있는 url", example = "https://iamsouf.s3.amazonaws.com/feed/original/example.jpg" )
         List<String> fileUrl,
 
         @Schema(description = "해당 공고문/피드의 원래 파일 이름", example = "[fileName, pictureName, spring, hihi]")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
@@ -32,21 +32,21 @@ public interface MemberApiSpecification {
             @PathVariable Long id
     );
 
-    @Operation(summary = "카테고리로 회원 검색", description = "1~3차 카테고리 필터에 해당하는 회원 목록을 페이징하여 조회합니다.")
-    @GetMapping("/member/search")
-    SuccessResponse<Page<MemberResDto>> findByCategory(
-            @RequestParam(required = false) Long first,
-            @PageableDefault(size = 6)
-            Pageable pageable
-    );
-
-    @Operation(summary = "닉네임으로 회원 검색", description = "닉네임에 키워드(검색어)가 포함된 회원 목록을 페이징하여 조회합니다.")
-    @GetMapping("/member/search/nickname")
-    SuccessResponse<Page<MemberResDto>> findByNickname(
-            @RequestParam String keyword,
-            @PageableDefault(size = 6)
-            Pageable pageable
-    );
+//    @Operation(summary = "카테고리로 회원 검색", description = "1~3차 카테고리 필터에 해당하는 회원 목록을 페이징하여 조회합니다.")
+//    @GetMapping("/member/search")
+//    SuccessResponse<Page<MemberResDto>> findByCategory(
+//            @RequestParam(required = false) Long first,
+//            @PageableDefault(size = 6)
+//            Pageable pageable
+//    );
+//
+//    @Operation(summary = "닉네임으로 회원 검색", description = "닉네임에 키워드(검색어)가 포함된 회원 목록을 페이징하여 조회합니다.")
+//    @GetMapping("/member/search/nickname")
+//    SuccessResponse<Page<MemberResDto>> findByNickname(
+//            @RequestParam String keyword,
+//            @PageableDefault(size = 6)
+//            Pageable pageable
+//    );
 
     @Operation(summary = "회원정보 수정", description = "로그인된 사용자의 회원정보를 업데이트합니다.")
     @PutMapping("/update")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/member")
 public interface MemberApiSpecification {
 
-    @Operation(summary = "회원 목록 조회", description = "모든 회원의 정보를 페이징하여 조회합니다.")
+    @Operation(summary = "회원 목록 조회", description = "카테고리와 검색어로 필터링한 회원 목록을 페이징하여 조회합니다.")
     @GetMapping("/member")
     SuccessResponse<Page<MemberSimpleResDto>> getMembers(
             @RequestParam(name = "firstCategory") Long first,

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
@@ -1,7 +1,9 @@
 package com.souf.soufwebsite.domain.member.controller;
 
+import com.souf.soufwebsite.domain.member.dto.ReqDto.MemberSearchReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.UpdateReqDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
+import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,9 +19,12 @@ public interface MemberApiSpecification {
 
     @Operation(summary = "회원 목록 조회", description = "모든 회원의 정보를 페이징하여 조회합니다.")
     @GetMapping("/member")
-    SuccessResponse<Page<MemberResDto>> getMembers(
-            @PageableDefault(size = 6)
-            Pageable pageable
+    SuccessResponse<Page<MemberSimpleResDto>> getMembers(
+            @RequestParam(name = "firstCategory") Long first,
+            @RequestParam(name = "secondCategory", required = false) Long second,
+            @RequestParam(name = "thirdCategory", required = false) Long third,
+            @RequestParam String keyword,
+            @PageableDefault(size = 6) Pageable pageable
     );
 
     @Operation(summary = "내 정보 조회", description = "로그인된 사용자의 회원 정보를 조회합니다.")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
@@ -1,7 +1,9 @@
 package com.souf.soufwebsite.domain.member.controller;
 
+import com.souf.soufwebsite.domain.member.dto.ReqDto.MemberSearchReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.UpdateReqDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
+import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.domain.member.service.MemberService;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,10 +22,16 @@ public class MemberController implements MemberApiSpecification{
     private final MemberService memberService;
 
     @GetMapping
-    public SuccessResponse<Page<MemberResDto>> getMembers(
-            @PageableDefault(size = 6) Pageable pageable
-    ) {
-        return new SuccessResponse<>(memberService.getMembers(pageable));
+    public SuccessResponse<Page<MemberSimpleResDto>> getMembers(
+            @RequestParam(name = "firstCategory") Long first,
+            @RequestParam(name = "secondCategory", required = false) Long second,
+            @RequestParam(name = "thirdCategory", required = false) Long third,
+            @RequestParam(name = "keyword", required = false) String keyword,
+            @PageableDefault(size = 6) Pageable pageable) {
+
+        MemberSearchReqDto reqDto = new MemberSearchReqDto(keyword);
+        return new SuccessResponse<>(memberService.getMembers(first, second, third, reqDto, pageable),
+                "멤버 목록을 조회했습니다.");
     }
 
     @GetMapping("/myinfo")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
@@ -37,27 +37,27 @@ public class MemberController implements MemberApiSpecification{
         return new SuccessResponse<>(memberService.getMemberById(id));
     }
 
-    @GetMapping("/search")
-    public SuccessResponse<Page<MemberResDto>> findByCategory(
-            @RequestParam(required = false) Long first,
-            @PageableDefault(size = 6) Pageable pageable
-    ) {
-        return new SuccessResponse<>(
-                memberService.getMembersByCategory(first, pageable),
-                "카테고리로 검색한 멤버 목록입니다."
-        );
-    }
-
-    @GetMapping("/search/nickname")
-    public SuccessResponse<Page<MemberResDto>> findByNickname(
-            @RequestParam String keyword,
-            @PageableDefault(size = 6) Pageable pageable
-    ) {
-        return new SuccessResponse<>(
-                memberService.getMembersByNickname(keyword, pageable),
-                "닉네임으로 검색한 멤버 목록입니다."
-        );
-    }
+//    @GetMapping("/search")
+//    public SuccessResponse<Page<MemberResDto>> findByCategory(
+//            @RequestParam(required = false) Long first,
+//            @PageableDefault(size = 6) Pageable pageable
+//    ) {
+//        return new SuccessResponse<>(
+//                memberService.getMembersByCategory(first, pageable),
+//                "카테고리로 검색한 멤버 목록입니다."
+//        );
+//    }
+//
+//    @GetMapping("/search/nickname")
+//    public SuccessResponse<Page<MemberResDto>> findByNickname(
+//            @RequestParam String keyword,
+//            @PageableDefault(size = 6) Pageable pageable
+//    ) {
+//        return new SuccessResponse<>(
+//                memberService.getMembersByNickname(keyword, pageable),
+//                "닉네임으로 검색한 멤버 목록입니다."
+//        );
+//    }
 
     @PutMapping("/update")
     public SuccessResponse<?> updateUserInfo(@RequestBody UpdateReqDto reqDto) {

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/MemberSearchReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/MemberSearchReqDto.java
@@ -1,0 +1,6 @@
+package com.souf.soufwebsite.domain.member.dto.ReqDto;
+
+public record MemberSearchReqDto(
+        String keyword
+) {
+}

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/MemberSearchReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/MemberSearchReqDto.java
@@ -1,6 +1,9 @@
 package com.souf.soufwebsite.domain.member.dto.ReqDto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MemberSearchReqDto(
+        @Schema(description = "검색어", example = "디자인")
         String keyword
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/UpdateReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/UpdateReqDto.java
@@ -7,6 +7,9 @@ import java.util.List;
 
 public record UpdateReqDto(
 
+        @Schema(description = "프로필 이미지", example = "https://iamsouf.s3.amazonaws.com/profile/original/profile.jpg")
+        String profileImageUrl,
+
         @Schema(description = "사용자 실명", example = "홍길동")
         String username,
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ResDto/MemberSimpleResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ResDto/MemberSimpleResDto.java
@@ -1,0 +1,14 @@
+package com.souf.soufwebsite.domain.member.dto.ResDto;
+
+import java.util.List;
+
+public record MemberSimpleResDto(
+        String profileImageUrl,
+        String nickname,
+        String intro,
+        List<PopularFeedDto> popularFeeds
+) {
+    public record PopularFeedDto(
+            String imageUrl
+    ) {}
+}

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
@@ -1,7 +1,6 @@
 package com.souf.soufwebsite.domain.member.entity;
 
 import com.souf.soufwebsite.domain.feed.entity.Feed;
-import com.souf.soufwebsite.domain.file.entity.Media;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.UpdateReqDto;
 import com.souf.soufwebsite.global.common.BaseEntity;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
@@ -62,10 +61,6 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberCategoryMapping> categories = new ArrayList<>();
 
-    @OneToOne
-    @JoinColumn(name = "media_id")
-    private Media media;
-
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Feed> feeds = new ArrayList<>();
 
@@ -80,6 +75,7 @@ public class Member extends BaseEntity {
 
     // 회원 정보 업데이트 (업데이트 가능한 필드만 반영)
     public void updateInfo(UpdateReqDto dto) {
+        if (dto.profileImageUrl() != null) this.profileImageUrl = dto.profileImageUrl();
         if (dto.username() != null) this.username = dto.username();
         if (dto.nickname() != null) this.nickname = dto.nickname();
         if (dto.intro() != null) this.intro = dto.intro();

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
@@ -57,6 +57,8 @@ public class Member extends BaseEntity {
     @Column(length = 300)
     private String personalUrl;
 
+    private String profileImageUrl;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberCategoryMapping> categories = new ArrayList<>();
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberCustomRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberCustomRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.domain.Pageable;
 public interface MemberCustomRepository {
 //    Page<Member> findByCategory(Long first, Pageable pageable);
 
-//    Page<MemberSimpleResDto> getMemberList(Long first, Long second, Long third,
-//                                           MemberSearchReqDto searchReqDto, Pageable pageable);
+    Page<MemberSimpleResDto> getMemberList(Long first, Long second, Long third,
+                                           MemberSearchReqDto searchReqDto, Pageable pageable);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberCustomRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberCustomRepository.java
@@ -1,9 +1,14 @@
 package com.souf.soufwebsite.domain.member.reposiotry;
 
+import com.souf.soufwebsite.domain.member.dto.ReqDto.MemberSearchReqDto;
+import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MemberCustomRepository {
-    Page<Member> findByCategory(Long first, Pageable pageable);
+//    Page<Member> findByCategory(Long first, Pageable pageable);
+
+//    Page<MemberSimpleResDto> getMemberList(Long first, Long second, Long third,
+//                                           MemberSearchReqDto searchReqDto, Pageable pageable);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberCustomRepositoryImpl.java
@@ -1,7 +1,14 @@
 package com.souf.soufwebsite.domain.member.reposiotry;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.souf.soufwebsite.domain.feed.entity.Feed;
+import com.souf.soufwebsite.domain.feed.repository.FeedRepository;
+import com.souf.soufwebsite.domain.file.dto.MediaResDto;
+import com.souf.soufwebsite.domain.member.controller.MemberController;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.MemberSearchReqDto;
+import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,40 +25,108 @@ import static com.souf.soufwebsite.global.common.category.entity.QFirstCategory.
 public class MemberCustomRepositoryImpl implements MemberCustomRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final FeedRepository feedRepository;
 
-    @Override
-    public Page<Member> findByCategory(Long first, Pageable pageable) {
-        // 1) BooleanBuilder 를 사용해 동적 where 절 구성
-        BooleanBuilder builder = new BooleanBuilder();
-        if (first != null) {
-            builder.and(memberCategoryMapping.firstCategory.id.eq(first));
-        }
+//    @Override
+//    public Page<Member> findByCategory(Long first, Pageable pageable) {
+//        // 1) BooleanBuilder 를 사용해 동적 where 절 구성
+//        BooleanBuilder builder = new BooleanBuilder();
+//        if (first != null) {
+//            builder.and(memberCategoryMapping.firstCategory.id.eq(first));
+//        }
+//
+//        // 2) 페이징된 회원 목록 조회 (1차 카테고리만 join 및 필터)
+//        List<Member> content = queryFactory
+//                .selectDistinct(member)
+//                .from(member)
+//                .join(member.categories, memberCategoryMapping)
+//                .join(memberCategoryMapping.firstCategory, firstCategory)
+//                .where(builder)
+//                .offset(pageable.getOffset())
+//                .limit(pageable.getPageSize())
+//                .orderBy(member.lastModifiedTime.desc())
+//                .fetch();
+//
+//        // 3) 전체 개수(count)를 위한 쿼리
+//        Long total = queryFactory
+//                .select(member.countDistinct())
+//                .from(member)
+//                .join(member.categories, memberCategoryMapping)
+//                .where(builder)
+//                .fetchOne();
+//
+//        return new PageImpl<>(
+//                content,
+//                pageable,
+//                total != null ? total : 0L
+//        );
+//    }
 
-        // 2) 페이징된 회원 목록 조회 (1차 카테고리만 join 및 필터)
-        List<Member> content = queryFactory
-                .selectDistinct(member)
-                .from(member)
-                .join(member.categories, memberCategoryMapping)
-                .join(memberCategoryMapping.firstCategory, firstCategory)
-                .where(builder)
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(member.lastModifiedTime.desc())
-                .fetch();
-
-        // 3) 전체 개수(count)를 위한 쿼리
-        Long total = queryFactory
-                .select(member.countDistinct())
-                .from(member)
-                .join(member.categories, memberCategoryMapping)
-                .where(builder)
-                .fetchOne();
-
-        return new PageImpl<>(
-                content,
-                pageable,
-                total != null ? total : 0L
-        );
-    }
-
+//    @Override
+//    public Page<MemberSimpleResDto> getMemberList(Long first, Long second, Long third,
+//                                                  MemberSearchReqDto searchReqDto, Pageable pageable) {
+//
+//        // 1. 기본 조회
+//        List<MemberSimpleResDto> userList = queryFactory
+//                .selectDistinct(Projections.constructor(
+//                        MemberSimpleResDto.class,
+//                        member.profileImageUrl,
+//                        member.nickname,
+//                        member.intro
+//                ))
+//                .from(member)
+//                .leftJoin(member.categories, memberCategoryMapping)
+//                .where(
+//                        first != null ? memberCategoryMapping.firstCategory.id.eq(first) : null,
+//                        second != null ? memberCategoryMapping.secondCategory.id.eq(second) : null,
+//                        third != null ? memberCategoryMapping.thirdCategory.id.eq(third) : null,
+//                        searchReqDto.keyword() != null ? (
+//                                member.nickname.contains(searchReqDto.keyword())
+//                                        .or(member.intro.contains(searchReqDto.keyword()))
+//                        ) : null
+//                )
+//                .orderBy(member.lastModifiedTime.desc())
+//                .offset(pageable.getOffset())
+//                .limit(pageable.getPageSize())
+//                .fetch();
+//
+//        Long total = queryFactory
+//                .select(member.countDistinct())
+//                .from(member)
+//                .leftJoin(member.categories, memberCategoryMapping)
+//                .where(
+//                        first != null ? memberCategoryMapping.firstCategory.id.eq(first) : null,
+//                        second != null ? memberCategoryMapping.secondCategory.id.eq(second) : null,
+//                        third != null ? memberCategoryMapping.thirdCategory.id.eq(third) : null,
+//                        searchReqDto.keyword() != null ? (
+//                                member.nickname.contains(searchReqDto.keyword())
+//                                        .or(member.intro.contains(searchReqDto.keyword()))
+//                        ) : null
+//                )
+//                .fetchOne();
+//
+//        List<MemberSimpleResDto> finalizedList = userList.stream()
+//                .map(dto -> {
+//                    String presignedProfile = fileService.getPresignedUrl(dto.profileImageUrl());
+//
+//                    Member member = memberRepository.findByNickname(dto.nickname())
+//                            .orElseThrow();
+//
+//                    List<Feed> feeds = feedRepository.findTop3ByMemberOrderByViewCountDesc(member);
+//
+//                    //각 피드의 썸네일 → presigned URL 변환
+//                    List<MemberSimpleResDto.PopularFeedDto> feedDtos = feeds.stream()
+//                            .map(feed -> {
+//                                MediaResDto thumbnail = MediaResDto.fromFeedThumbnail(feed);
+//                                String presignedImageUrl = fileService.getPresignedUrl(thumbnail.fileUrl());
+//                                return new MemberSimpleResDto.PopularFeedDto(presignedImageUrl);
+//                            })
+//                            .toList();
+//
+//                    return new MemberSimpleResDto(presignedProfile, dto.nickname(), dto.intro(), feedDtos);
+//                })
+//                .toList();
+//
+//        return new PageImpl<>(finalizedList, pageable, total == null ? 0L : total);
+//    }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/reposiotry/MemberRepository.java
@@ -10,7 +10,9 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
     Optional<Member> findByEmail(String email);
 
-    Page<Member> findByNicknameContainingIgnoreCase(String keyword, Pageable pageable);
+    Optional<Member> findByNickname(String nickname);
+
+//    Page<Member> findByNicknameContainingIgnoreCase(String keyword, Pageable pageable);
 
     boolean existsByNickname(String nickname);
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
@@ -1,10 +1,8 @@
 package com.souf.soufwebsite.domain.member.service;
 
-import com.souf.soufwebsite.domain.member.dto.ReqDto.ResetReqDto;
-import com.souf.soufwebsite.domain.member.dto.ReqDto.SigninReqDto;
-import com.souf.soufwebsite.domain.member.dto.ReqDto.SignupReqDto;
-import com.souf.soufwebsite.domain.member.dto.ReqDto.UpdateReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.*;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
+import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,7 +22,7 @@ public interface MemberService {
 
     void updateUserInfo(UpdateReqDto reqDto);
 
-    Page<MemberResDto> getMembers(Pageable pageable);
+    Page<MemberSimpleResDto> getMembers(Long first, Long second, Long third, MemberSearchReqDto searchReqDto, Pageable pageable);
 
     MemberResDto getMyInfo();
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
@@ -30,9 +30,9 @@ public interface MemberService {
 
     MemberResDto getMemberById(Long id);
 
-    Page<MemberResDto> getMembersByCategory(Long first, Pageable pageable);
-
-    Page<MemberResDto> getMembersByNickname(String nickname, Pageable pageable);
+//    Page<MemberResDto> getMembersByCategory(Long first, Pageable pageable);
+//
+//    Page<MemberResDto> getMembersByNickname(String nickname, Pageable pageable);
 
     boolean isNicknameAvailable(String nickname);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package com.souf.soufwebsite.domain.member.service;
 
 import com.souf.soufwebsite.domain.member.dto.ReqDto.*;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
+import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import com.souf.soufwebsite.domain.member.entity.*;
 import com.souf.soufwebsite.domain.member.exception.*;
@@ -181,15 +182,21 @@ public class MemberServiceImpl implements MemberService {
         }
     }
 
-    //회원 목록 조회
     @Override
-    public Page<MemberResDto> getMembers(Pageable pageable) {
-        return memberRepository.findAll(pageable)
-                .map(MemberResDto::from);
+    @Transactional(readOnly = true)
+    public Page<MemberSimpleResDto> getMembers(
+            Long first, Long second, Long third,
+            MemberSearchReqDto searchReqDto,
+            Pageable pageable) {
+        categoryService.validate(first, second, third);
+
+        return memberRepository.getMemberList(first, second, third, searchReqDto, pageable);
     }
+
 
     //내 정보 조회
     @Override
+    @Transactional(readOnly = true)
     public MemberResDto getMyInfo() {
         Member member = getCurrentUser();
         return MemberResDto.from(member);
@@ -197,6 +204,7 @@ public class MemberServiceImpl implements MemberService {
 
     //회원 조회
     @Override
+    @Transactional(readOnly = true)
     public MemberResDto getMemberById(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(NotFoundMemberException::new);
         return MemberResDto.from(member);

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -202,17 +202,17 @@ public class MemberServiceImpl implements MemberService {
         return MemberResDto.from(member);
     }
 
-    @Override
-    public Page<MemberResDto> getMembersByCategory(Long first, Pageable pageable) {
-        Page<Member> result = memberRepository.findByCategory(first, pageable);
-        return result.map(MemberResDto::from);
-    }
-
-    @Override
-    public Page<MemberResDto> getMembersByNickname(String nickname, Pageable pageable) {
-        Page<Member> result = memberRepository.findByNicknameContainingIgnoreCase(nickname, pageable);
-        return result.map(MemberResDto::from);
-    }
+//    @Override
+//    public Page<MemberResDto> getMembersByCategory(Long first, Pageable pageable) {
+//        Page<Member> result = memberRepository.findByCategory(first, pageable);
+//        return result.map(MemberResDto::from);
+//    }
+//
+//    @Override
+//    public Page<MemberResDto> getMembersByNickname(String nickname, Pageable pageable) {
+//        Page<Member> result = memberRepository.findByNicknameContainingIgnoreCase(nickname, pageable);
+//        return result.map(MemberResDto::from);
+//    }
 
     @Override
     public boolean isNicknameAvailable(String nickname) {

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/RecruitReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/RecruitReqDto.java
@@ -46,7 +46,7 @@ public record RecruitReqDto(
         @NotNull(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
         List<CategoryDto> categoryDtos,
 
-        @Schema(description = "원본 파일 이름 리스트, 없으면 [] 이렇게 빈 리스트로 반환해주세요.", example = "[fileName.jpg, dog.jpg..]")
+        @Schema(description = "원본 파일 이름 리스트, 없으면 [] 이렇게 빈 리스트로 반환해주세요.", example = "[\"fileName.jpg\", \"dog.jpg\"]")
         List<String> originalFileNames
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/RecruitSimpleResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/RecruitSimpleResDto.java
@@ -1,12 +1,14 @@
 package com.souf.soufwebsite.domain.recruit.dto;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public record RecruitSimpleResDto(
 
         Long recruitId,
         String title,
-        Long secondCategory,
+        List<Long> secondCategory,
         String content,
         String payment,
         String region,
@@ -14,4 +16,19 @@ public record RecruitSimpleResDto(
         Long recruitCount,
         LocalDateTime lastModified
 ) {
+    public static RecruitSimpleResDto of(Long recruitId, String title, Long secondCategoryId, String content,
+                                         String payment, String region, LocalDateTime deadLine,
+                                         Long recruitCount, LocalDateTime lastModified) {
+        return new RecruitSimpleResDto(
+                recruitId, title,
+                new ArrayList<>(List.of(secondCategoryId)), // 초기 리스트
+                content, payment, region, deadLine, recruitCount, lastModified
+        );
+    }
+
+    public void addSecondCategory(Long id) {
+        if (!this.secondCategory.contains(id)) {
+            this.secondCategory.add(id);
+        }
+    }
 }


### PR DESCRIPTION
## 개요
공고문을 전체 검색 결과에서 공고문 Id로 중복 제거할 수 있도록 수정하였습니다.
카테고리와 검색어로 필터링한 유저 리스트를 6명씩 페이징하여 반환합니다.
프로필 이미지를 설정할 수 있습니다.

## 진행한 이슈
- close #62 

## 구현 내용
- 공고문 조회 필터링이 대분류 뿐만 아니라 전체를 고려해서, 공고문 Id로 중복 제거 할 수 있도록 수정하였습니다.
- 유저 조회 또한 카테고리와 검색어를 모두 고려해서 중복 제거하도록 구현했습니다.
- 회원 정보 수정에서 프로필 이미지를 추가할 수 있도록 구현했습니다.

## 참고 자료
- ![image](https://github.com/user-attachments/assets/4483a227-05ca-4695-a1fe-1f867bb94792)
