### PR TITLE
[Fix] 회원가입 로직 수정

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -4,6 +4,7 @@ import com.souf.soufwebsite.domain.member.dto.ReqDto.ResetReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.SigninReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.SignupReqDto;
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
+import com.souf.soufwebsite.domain.member.service.VerificationPurpose;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -45,11 +46,14 @@ public interface AuthApiSpecification {
             @RequestParam String email
     );
 
-    @Operation(summary = "이메일 인증번호 검증", description = "이메일로 발급된 인증번호와 일치하게 입력하였는지 검증합니다.")
+    @Operation(summary = "이메일 인증번호 검증",
+            description = "이메일로 발급된 인증번호와 일치하게 입력하였는지 검증합니다.<br>" +
+                    " 인증 목적에 따라 (SIGNUP) 또는 (RESET)을 입력합니다.")
     @PostMapping("/email/verify")
     SuccessResponse<Boolean> verifyEmailCode(
             @RequestParam String email,
-            @RequestParam String code
+            @RequestParam String code,
+            @RequestParam VerificationPurpose purpose
     );
 
     @Operation(summary = "닉네임 중복 검증", description = "입력된 닉네임이 사용 가능한지 확인합니다.")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
@@ -5,6 +5,7 @@ import com.souf.soufwebsite.domain.member.dto.ReqDto.SigninReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.SignupReqDto;
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import com.souf.soufwebsite.domain.member.service.MemberService;
+import com.souf.soufwebsite.domain.member.service.VerificationPurpose;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
@@ -52,8 +53,11 @@ public class AuthController implements AuthApiSpecification{
 
     // 인증번호 검증
     @PostMapping("/email/verify")
-    public SuccessResponse<Boolean> verifyEmailCode(@RequestParam String email, @RequestParam String code) {
-        boolean verified = memberService.verifyEmail(email, code);
+    public SuccessResponse<Boolean> verifyEmailCode(
+            @RequestParam String email,
+            @RequestParam String code,
+            @RequestParam VerificationPurpose purpose) {
+        boolean verified = memberService.verifyEmail(email, code, purpose);
         return new SuccessResponse<>(verified);
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/SignupReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/SignupReqDto.java
@@ -28,7 +28,7 @@ public record SignupReqDto(
         @Schema(description = "비밀번호 확인", example = "Passw0rd!")
         @NotEmpty String passwordCheck,
 
-        @Schema(description = "카테고리 목록", example = "[{\"firstCategory\": 1, \"secondCategory\": 1}, {\"thirdCategory\": 1}]")
+        @Schema(description = "카테고리 목록", example = "[{\"firstCategory\": 1, \"secondCategory\": 1, \"thirdCategory\": 1}]")
         List<CategoryDto> categoryDtos
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/exception/ErrorType.java
@@ -9,7 +9,8 @@ public enum ErrorType {
 
     NOT_AVAILABLE_EMAIL(400, "이미 존재하는 이메일입니다."),
     NOT_MATCH_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
-    NOT_FOUND_MEMBER(404, "해당 사용자를 찾을 수 없습니다.");
+    NOT_FOUND_MEMBER(404, "해당 사용자를 찾을 수 없습니다."),
+    NOT_VERIFIED_EMAIL(400, "이메일 인증이 완료되지 않았습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/member/exception/NotVerifiedEmailException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/exception/NotVerifiedEmailException.java
@@ -1,0 +1,9 @@
+package com.souf.soufwebsite.domain.member.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.member.exception.ErrorType.NOT_VERIFIED_EMAIL;
+
+public class NotVerifiedEmailException extends BaseErrorException {
+  public NotVerifiedEmailException() { super(NOT_VERIFIED_EMAIL.getCode(), NOT_VERIFIED_EMAIL.getMessage()); }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
@@ -20,7 +20,7 @@ public interface MemberService {
 
     boolean sendResetEmailVerification(String email);
 
-    boolean verifyEmail(String email, String code);
+    boolean verifyEmail(String email, String code, VerificationPurpose purpose);
 
     MemberUpdateResDto updateUserInfo(UpdateReqDto reqDto);
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -169,15 +169,16 @@ public class MemberServiceImpl implements MemberService {
     //인증번호 확인
     @Override
     @Transactional
-    public boolean verifyEmail(String email, String code) {
+    public boolean verifyEmail(String email, String code, VerificationPurpose purpose) {
         String emailKey = "email:verification:" + email; // Redis에서 인증번호 키
         String verifiedKey = "email:verified:" + email; // Redis에서 인증 완료된 이메일 키
 
         String storedCode = redisTemplate.opsForValue().get(emailKey);
 
         if (storedCode != null && storedCode.equals(code)) {
-            // 인증 완료 상태 저장 (예: 30분 동안 유효)
-            redisTemplate.opsForValue().set(verifiedKey, "true", Duration.ofMinutes(30));
+            if (purpose == VerificationPurpose.SIGNUP) {
+                redisTemplate.opsForValue().set(verifiedKey, "true", Duration.ofMinutes(30));
+            }
             return true;
         }
         return false;

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/VerificationPurpose.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/VerificationPurpose.java
@@ -1,0 +1,5 @@
+package com.souf.soufwebsite.domain.member.service;
+
+public enum VerificationPurpose {
+    SIGNUP, RESET
+}


### PR DESCRIPTION
## 개요
회원가입 로직(이메일 검증) 수정 및 목적에 대한 분리

## 진행한 이슈
- close #74 

## 구현 내용
- 회원가입 로직 중 이메일 검증 순서에 대한 틀린 로직이 있었습니다. 이메일 검증이 완료된 이메일만 회원가입이 가능하도록 redis를 사용했습니다.
- <img width="772" alt="image" src="https://github.com/user-attachments/assets/e2e1467e-1996-4da7-98d8-792839b65202" />

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
