### PR TITLE
[Fix] 지연 로딩 오류 수정

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedDetailResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedDetailResDto.java
@@ -1,9 +1,11 @@
 package com.souf.soufwebsite.domain.feed.dto;
 
 import com.souf.soufwebsite.domain.feed.entity.Feed;
+import com.souf.soufwebsite.domain.feed.entity.FeedCategoryMapping;
 import com.souf.soufwebsite.domain.file.dto.MediaResDto;
 import com.souf.soufwebsite.domain.file.entity.Media;
 import com.souf.soufwebsite.domain.member.entity.Member;
+import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,6 +21,7 @@ public record FeedDetailResDto(
         String content,
         Long view,
         List<MediaResDto> mediaResDtos,
+        List<CategoryDto> categoryDtos,
         LocalDateTime lastModifiedTime
 ) {
     public static FeedDetailResDto from(Member member, String profileUrl, Feed feed, Long feedViewCount, List<Media> mediaList) {
@@ -31,12 +34,19 @@ public record FeedDetailResDto(
             feed.getContent(),
             feed.getViewCount() + feedViewCount,
             convertToMediaResDto(mediaList),
+            convertToCategoryDto(feed.getCategories()),
             feed.getLastModifiedTime());
     }
 
     private static List<MediaResDto> convertToMediaResDto(List<Media> mediaList){
         return mediaList.stream().map(
                 MediaResDto::fromFeedDetail
+        ).collect(Collectors.toList());
+    }
+
+    private static List<CategoryDto> convertToCategoryDto(List<FeedCategoryMapping> mappings){
+        return mappings.stream().map(
+                m -> new CategoryDto(m.getFirstCategory().getId(), m.getSecondCategory().getId(), m.getThirdCategory().getId())
         ).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
@@ -107,7 +107,6 @@ public class Member extends BaseEntity {
             throw new NotExceedCategoryLimitException();
         }
         this.categories.add(mapping);
-        mapping.setMember(this);
     }
 
     public void updateCategory(CategoryDto oldDto, MemberCategoryMapping newMapping) {

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/MemberCategoryMapping.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/MemberCategoryMapping.java
@@ -18,7 +18,6 @@ public class MemberCategoryMapping {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/MemberCategoryMapping.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/MemberCategoryMapping.java
@@ -18,6 +18,7 @@ public class MemberCategoryMapping {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,6 +32,7 @@ public class MemberCategoryMapping {
 
     public static MemberCategoryMapping of(Member member, FirstCategory first, SecondCategory second, ThirdCategory third) {
         MemberCategoryMapping mapping = new MemberCategoryMapping();
+        mapping.member = member;
         mapping.firstCategory = first;
         mapping.secondCategory = second;
         mapping.thirdCategory = third;
@@ -41,10 +43,6 @@ public class MemberCategoryMapping {
         return this.firstCategory.getId().equals(mapping.firstCategory.getId())
                 && this.secondCategory.getId().equals(mapping.secondCategory.getId())
                 && this.thirdCategory.getId().equals(mapping.thirdCategory.getId());
-    }
-
-    public void setMember(Member member) {
-        this.member = member;
     }
 
     public void disconnectMember() {

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -39,7 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -240,8 +239,9 @@ public class MemberServiceImpl implements MemberService {
     @Transactional(readOnly = true)
     public MemberResDto getMyInfo() {
         Member member = getCurrentUser();
+        Member myMember = memberRepository.findById(member.getId()).orElseThrow(NotFoundMemberException::new); // 지연 로딩 오류 해결
         String mediaUrl = fileService.getMediaUrl(PostType.PROFILE, member.getId());
-        return MemberResDto.from(member, mediaUrl);
+        return MemberResDto.from(myMember, mediaUrl);
     }
 
     //회원 조회


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- close #84 

## 구현 내용
- [x] 이슈에 기입된 사항들을 모두 충족했나요?
1. 피드 상세 조회 시 카테고리를 반환하도록 수정
2. 대학생-카테고리 간 매핑 관계 수정
3. 대학생 마이페이지 조회 시 LAZY 로딩 오류 수정

## 참고 자료
- 현 사용자의 마이페이지 조회 시 getCurrentUser에서 가져오는 객체에 대해 영속성 컨텍스트가 적용되지 않아 DB를 가져오지 못하는 상황이 발생하였습니다. 그래서 getCurrentUser에서 가져온 Member객체의 아이디를 이용하여 세션에서 객체를 가져와 지연로딩을 이루어지게 하였습니다. 
