### PR TITLE
[Feat] 기존 회원의 권한 전환

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
@@ -60,6 +60,13 @@ public interface MemberApiSpecification {
             @RequestBody @Valid UpdateReqDto reqDto
     );
 
+    @Operation(summary = "이메일 인증번호 전송", description = "기존 회원의 이메일 인증을 위해 인증번호를 전송합니다.")
+    @PostMapping("/modify/email/send")
+    SuccessResponse<Boolean> sendModifyEmailVerification(
+            @RequestParam String originalEmail,
+            @RequestParam String acKrEmail
+    );
+
     @Operation(summary = "회원프로필 업로드", description = "회원프로필을 업로드한 후의 파일정보를 저장합니다.")
     @PostMapping("/upload")
     SuccessResponse uploadMetadata(@Valid @RequestBody MediaReqDto mediaReqDto);

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
@@ -1,6 +1,8 @@
 package com.souf.soufwebsite.domain.member.controller;
 
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.SendEmailReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.SendModifyEmailReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.UpdateReqDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
@@ -63,8 +65,7 @@ public interface MemberApiSpecification {
     @Operation(summary = "이메일 인증번호 전송", description = "기존 회원의 이메일 인증을 위해 인증번호를 전송합니다.")
     @PostMapping("/modify/email/send")
     SuccessResponse<Boolean> sendModifyEmailVerification(
-            @RequestParam String originalEmail,
-            @RequestParam String acKrEmail
+            @RequestBody @Valid SendModifyEmailReqDto reqDto
     );
 
     @Operation(summary = "회원프로필 업로드", description = "회원프로필을 업로드한 후의 파일정보를 저장합니다.")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.souf.soufwebsite.domain.member.controller;
 
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.MemberSearchReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.SendModifyEmailReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.UpdateReqDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
@@ -78,8 +79,8 @@ public class MemberController implements MemberApiSpecification{
 
     @PostMapping("/modify/email/send")
     public SuccessResponse<Boolean> sendModifyEmailVerification(
-            @RequestParam String originalEmail, @RequestParam String acKrEmail) {
-        return new SuccessResponse<>(memberService.sendModifyEmailVerification(originalEmail, acKrEmail));
+            @RequestBody @Valid SendModifyEmailReqDto reqDto) {
+        return new SuccessResponse<>(memberService.sendModifyEmailVerification(reqDto));
     }
 
     @PostMapping("/upload")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
@@ -76,6 +76,12 @@ public class MemberController implements MemberApiSpecification{
         return new SuccessResponse<>(resDto, "회원정보 수정 성공");
     }
 
+    @PostMapping("/modify/email/send")
+    public SuccessResponse<Boolean> sendModifyEmailVerification(
+            @RequestParam String originalEmail, @RequestParam String acKrEmail) {
+        return new SuccessResponse<>(memberService.sendModifyEmailVerification(originalEmail, acKrEmail));
+    }
+
     @PostMapping("/upload")
     public SuccessResponse uploadMetadata(@Valid @RequestBody MediaReqDto mediaReqDto){
         memberService.uploadProfileMedia(mediaReqDto);

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -46,6 +46,12 @@ public interface AuthApiSpecification {
             @RequestParam String email
     );
 
+    @Operation(summary = "이메일 인증번호 전송", description = "기존 회원의 이메일 인증을 위해 인증번호를 전송합니다.")
+    @PostMapping("/certify/email/send")
+    SuccessResponse<Boolean> sendCertifyEmailVerification(
+            @RequestParam String email
+    );
+
     @Operation(summary = "이메일 인증번호 검증",
             description = "이메일로 발급된 인증번호와 일치하게 입력하였는지 검증합니다.<br>" +
                     " 인증 목적에 따라 (SIGNUP) 또는 (RESET)을 입력합니다.")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -46,13 +46,6 @@ public interface AuthApiSpecification {
             @RequestParam String email
     );
 
-    @Operation(summary = "이메일 인증번호 전송", description = "기존 회원의 이메일 인증을 위해 인증번호를 전송합니다.")
-    @PostMapping("/modify/email/send")
-    SuccessResponse<Boolean> sendModifyEmailVerification(
-            @RequestParam String originalEmail,
-            @RequestParam String acKrEmail
-    );
-
     @Operation(summary = "이메일 인증번호 검증",
             description = "이메일로 발급된 인증번호와 일치하게 입력하였는지 검증합니다.<br>" +
                     " 인증 목적에 따라 (SIGNUP) 또는 (RESET)을 입력합니다.")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -1,8 +1,6 @@
 package com.souf.soufwebsite.domain.member.controller.auth;
 
-import com.souf.soufwebsite.domain.member.dto.ReqDto.ResetReqDto;
-import com.souf.soufwebsite.domain.member.dto.ReqDto.SigninReqDto;
-import com.souf.soufwebsite.domain.member.dto.ReqDto.SignupReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.*;
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import com.souf.soufwebsite.domain.member.service.VerificationPurpose;
 import com.souf.soufwebsite.global.success.SuccessResponse;
@@ -37,13 +35,13 @@ public interface AuthApiSpecification {
     @Operation(summary = "이메일 인증번호 전송", description = "회원가입 시 입력된 이메일로 인증번호를 전송합니다.")
     @PostMapping("/signup/email/send")
     SuccessResponse<Boolean> sendSignupEmailVerification(
-            @RequestParam String email
+            @RequestBody @Valid SendEmailReqDto reqDto
     );
 
     @Operation(summary = "이메일 인증번호 전송", description = "비밀번호 재설정 시 입력된 이메일로 인증번호를 전송합니다.")
     @PostMapping("/reset/email/send")
     SuccessResponse<Boolean> sendResetEmailVerification(
-            @RequestParam String email
+            @RequestBody @Valid SendEmailReqDto reqDto
     );
 
     @Operation(summary = "이메일 인증번호 검증",
@@ -51,9 +49,7 @@ public interface AuthApiSpecification {
                     " 인증 목적에 따라 (SIGNUP), (RESET) 또는 (MODIFY)를 입력합니다.")
     @PostMapping("/email/verify")
     SuccessResponse<Boolean> verifyEmailCode(
-            @RequestParam String email,
-            @RequestParam String code,
-            @RequestParam VerificationPurpose purpose
+            @RequestBody @Valid VerifyEmailReqDto reqDto
     );
 
     @Operation(summary = "닉네임 중복 검증", description = "입력된 닉네임이 사용 가능한지 확인합니다.")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -47,9 +47,10 @@ public interface AuthApiSpecification {
     );
 
     @Operation(summary = "이메일 인증번호 전송", description = "기존 회원의 이메일 인증을 위해 인증번호를 전송합니다.")
-    @PostMapping("/certify/email/send")
-    SuccessResponse<Boolean> sendCertifyEmailVerification(
-            @RequestParam String email
+    @PostMapping("/modify/email/send")
+    SuccessResponse<Boolean> sendModifyEmailVerification(
+            @RequestParam String originalEmail,
+            @RequestParam String acKrEmail
     );
 
     @Operation(summary = "이메일 인증번호 검증",

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -48,7 +48,7 @@ public interface AuthApiSpecification {
 
     @Operation(summary = "이메일 인증번호 검증",
             description = "이메일로 발급된 인증번호와 일치하게 입력하였는지 검증합니다.<br>" +
-                    " 인증 목적에 따라 (SIGNUP) 또는 (RESET)을 입력합니다.")
+                    " 인증 목적에 따라 (SIGNUP), (RESET) 또는 (MODIFY)를 입력합니다.")
     @PostMapping("/email/verify")
     SuccessResponse<Boolean> verifyEmailCode(
             @RequestParam String email,

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
@@ -1,9 +1,6 @@
 package com.souf.soufwebsite.domain.member.controller.auth;
 
-import com.souf.soufwebsite.domain.member.dto.ReqDto.ResetReqDto;
-import com.souf.soufwebsite.domain.member.dto.ReqDto.SigninReqDto;
-import com.souf.soufwebsite.domain.member.dto.ReqDto.SignupReqDto;
-import com.souf.soufwebsite.domain.member.dto.ReqDto.WithdrawReqDto;
+import com.souf.soufwebsite.domain.member.dto.ReqDto.*;
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import com.souf.soufwebsite.domain.member.service.MemberService;
 import com.souf.soufwebsite.domain.member.service.VerificationPurpose;
@@ -43,22 +40,19 @@ public class AuthController implements AuthApiSpecification{
 
     // 인증번호 전송
     @PostMapping("/signup/email/send")
-    public SuccessResponse<Boolean> sendSignupEmailVerification(@RequestParam String email) {
-        return new SuccessResponse<>(memberService.sendSignupEmailVerification(email));
+    public SuccessResponse<Boolean> sendSignupEmailVerification(@RequestBody SendEmailReqDto reqDto) {
+        return new SuccessResponse<>(memberService.sendSignupEmailVerification(reqDto));
     }
 
     @PostMapping("/reset/email/send")
-    public SuccessResponse<Boolean> sendResetEmailVerification(@RequestParam String email) {
-        return new SuccessResponse<>(memberService.sendResetEmailVerification(email));
+    public SuccessResponse<Boolean> sendResetEmailVerification(@RequestBody SendEmailReqDto reqDto) {
+        return new SuccessResponse<>(memberService.sendResetEmailVerification(reqDto));
     }
 
     // 인증번호 검증
     @PostMapping("/email/verify")
-    public SuccessResponse<Boolean> verifyEmailCode(
-            @RequestParam String email,
-            @RequestParam String code,
-            @RequestParam VerificationPurpose purpose) {
-        boolean verified = memberService.verifyEmail(email, code, purpose);
+    public SuccessResponse<Boolean> verifyEmailCode(@RequestBody @Valid VerifyEmailReqDto reqDto) {
+        boolean verified = memberService.verifyEmail(reqDto);
         return new SuccessResponse<>(verified);
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
@@ -52,12 +52,6 @@ public class AuthController implements AuthApiSpecification{
         return new SuccessResponse<>(memberService.sendResetEmailVerification(email));
     }
 
-    @PostMapping("/modify/email/send")
-    public SuccessResponse<Boolean> sendModifyEmailVerification(
-            @RequestParam String originalEmail, @RequestParam String acKrEmail) {
-        return new SuccessResponse<>(memberService.sendModifyEmailVerification(originalEmail, acKrEmail));
-    }
-
     // 인증번호 검증
     @PostMapping("/email/verify")
     public SuccessResponse<Boolean> verifyEmailCode(

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
@@ -52,9 +52,10 @@ public class AuthController implements AuthApiSpecification{
         return new SuccessResponse<>(memberService.sendResetEmailVerification(email));
     }
 
-    @PostMapping("/certify/email/send")
-    public SuccessResponse<Boolean> sendCertifyEmailVerification(@RequestParam String email) {
-        return new SuccessResponse<>(memberService.sendCertifyEmailVerification(email));
+    @PostMapping("/modify/email/send")
+    public SuccessResponse<Boolean> sendModifyEmailVerification(
+            @RequestParam String originalEmail, @RequestParam String acKrEmail) {
+        return new SuccessResponse<>(memberService.sendModifyEmailVerification(originalEmail, acKrEmail));
     }
 
     // 인증번호 검증
@@ -66,6 +67,7 @@ public class AuthController implements AuthApiSpecification{
         boolean verified = memberService.verifyEmail(email, code, purpose);
         return new SuccessResponse<>(verified);
     }
+
 
     // 이메일 중복 검증
     @GetMapping("/nickname/available")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
@@ -52,6 +52,11 @@ public class AuthController implements AuthApiSpecification{
         return new SuccessResponse<>(memberService.sendResetEmailVerification(email));
     }
 
+    @PostMapping("/certify/email/send")
+    public SuccessResponse<Boolean> sendCertifyEmailVerification(@RequestParam String email) {
+        return new SuccessResponse<>(memberService.sendCertifyEmailVerification(email));
+    }
+
     // 인증번호 검증
     @PostMapping("/email/verify")
     public SuccessResponse<Boolean> verifyEmailCode(

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/SendEmailReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/SendEmailReqDto.java
@@ -1,0 +1,12 @@
+package com.souf.soufwebsite.domain.member.dto.ReqDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+
+public record SendEmailReqDto(
+        @Schema(description = "인증번호를 전송할 이메일", example = "test@test.com")
+        @NotEmpty @Email
+        String email
+) {
+}

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/SendModifyEmailReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/SendModifyEmailReqDto.java
@@ -1,0 +1,15 @@
+package com.souf.soufwebsite.domain.member.dto.ReqDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+
+public record SendModifyEmailReqDto(
+        @Schema(description = "기존의 회원가입에 사용한 일반 이메일", example = "test@test.com")
+        @NotEmpty @Email
+        String originalEmail,
+        @Schema(description = "학생 인증에 사용할 이메일", example = "test@test.ac.kr")
+        @NotEmpty @Email
+        String acKrEmail
+) {
+}

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/VerifyEmailReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ReqDto/VerifyEmailReqDto.java
@@ -1,0 +1,20 @@
+package com.souf.soufwebsite.domain.member.dto.ReqDto;
+
+import com.souf.soufwebsite.domain.member.service.VerificationPurpose;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record VerifyEmailReqDto(
+        @Schema(description = "인증번호를 전송한 이메일", example = "test@test.com")
+        @NotBlank @Email
+        String email,
+        @Schema(description = "인증번호", example = "123456")
+        @NotBlank
+        String code,
+        @Schema(description = "인증번호 확인 목적", example = "SIGNUP, RESET, MODIFY")
+        @NotNull
+        VerificationPurpose purpose
+) {
+}

--- a/src/main/java/com/souf/soufwebsite/domain/member/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/exception/ErrorType.java
@@ -10,7 +10,8 @@ public enum ErrorType {
     NOT_AVAILABLE_EMAIL(400, "이미 존재하는 이메일입니다."),
     NOT_MATCH_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
     NOT_FOUND_MEMBER(404, "해당 사용자를 찾을 수 없습니다."),
-    NOT_VERIFIED_EMAIL(400, "이메일 인증이 완료되지 않았습니다.");
+    NOT_VERIFIED_EMAIL(400, "이메일 인증이 완료되지 않았습니다."),
+    NOT_VALID_EMAIL(400, "유효하지 않은 이메일 형식입니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/member/exception/NotValidEmailException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/exception/NotValidEmailException.java
@@ -1,0 +1,9 @@
+package com.souf.soufwebsite.domain.member.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.member.exception.ErrorType.NOT_VALID_EMAIL;
+
+public class NotValidEmailException extends BaseErrorException {
+    public NotValidEmailException() { super(NOT_VALID_EMAIL.getCode(), NOT_VALID_EMAIL.getMessage()); }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
@@ -16,13 +16,13 @@ public interface MemberService {
 
     void resetPassword(ResetReqDto reqDto);
 
-    boolean sendSignupEmailVerification(String email);
+    boolean sendSignupEmailVerification(SendEmailReqDto reqDto);
 
-    boolean sendResetEmailVerification(String email);
+    boolean sendResetEmailVerification(SendEmailReqDto reqDto);
 
-    boolean sendModifyEmailVerification(String originalEmail, String acKrEmail);
+    boolean sendModifyEmailVerification(SendModifyEmailReqDto reqDto);
 
-    boolean verifyEmail(String email, String code, VerificationPurpose purpose);
+    boolean verifyEmail(VerifyEmailReqDto reqDto);
 
     MemberUpdateResDto updateUserInfo(UpdateReqDto reqDto);
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
@@ -20,7 +20,7 @@ public interface MemberService {
 
     boolean sendResetEmailVerification(String email);
 
-    boolean sendCertifyEmailVerification(String email);
+    boolean sendModifyEmailVerification(String originalEmail, String acKrEmail);
 
     boolean verifyEmail(String email, String code, VerificationPurpose purpose);
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
@@ -20,6 +20,8 @@ public interface MemberService {
 
     boolean sendResetEmailVerification(String email);
 
+    boolean sendCertifyEmailVerification(String email);
+
     boolean verifyEmail(String email, String code, VerificationPurpose purpose);
 
     MemberUpdateResDto updateUserInfo(UpdateReqDto reqDto);

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/VerificationPurpose.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/VerificationPurpose.java
@@ -1,5 +1,5 @@
 package com.souf.soufwebsite.domain.member.service;
 
 public enum VerificationPurpose {
-    SIGNUP, RESET, CERTIFY
+    SIGNUP, RESET, MODIFY
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/VerificationPurpose.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/VerificationPurpose.java
@@ -1,5 +1,5 @@
 package com.souf.soufwebsite.domain.member.service;
 
 public enum VerificationPurpose {
-    SIGNUP, RESET
+    SIGNUP, RESET, CERTIFY
 }


### PR DESCRIPTION
## 개요
일반 회원으로 회원가입한 계정이 ac.kr로 인증 후 학생 권한으로 전환합니다.

## 진행한 이슈
- close #86 

## 구현 내용
<img width="888" alt="image" src="https://github.com/user-attachments/assets/1e455aef-c160-4041-8479-716e57e92147" />
기존의 이메일과 ac.kr 이메일을 모두 파라미터로 필요합니다.
<img width="635" alt="image" src="https://github.com/user-attachments/assets/a13f30eb-683b-4d4d-9e9b-243ff26bf174" />
ac.kr 이메일로 인증번호 인증을 할 경우 role을 STUDENT로 전환합니다.

/modify/email/send api는 학생 정보의 수정이기 때문에 auth 가 아닌 memberController 에 위치합니다.

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
