### PR TITLE
[Feat] 토큰 재발급 분리

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -8,6 +8,7 @@ import com.souf.soufwebsite.domain.member.service.VerificationPurpose;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +26,8 @@ public interface AuthApiSpecification {
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 토큰을 발급받습니다.")
     @PostMapping("/login")
     SuccessResponse<TokenDto> signin(
-            @RequestBody @Valid SigninReqDto reqDto
+            @RequestBody @Valid SigninReqDto reqDto,
+            HttpServletResponse response
     );
 
     @Operation(summary = "비밀번호 재설정", description = "입력한 새 비밀번호로 계정 비밀번호를 변경합니다.")

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
@@ -8,6 +8,7 @@ import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import com.souf.soufwebsite.domain.member.service.MemberService;
 import com.souf.soufwebsite.domain.member.service.VerificationPurpose;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
@@ -28,9 +29,9 @@ public class AuthController implements AuthApiSpecification{
     }
 
     @PostMapping("/login")
-    public SuccessResponse<TokenDto> signin(@RequestBody @Valid SigninReqDto reqDto) {
+    public SuccessResponse<TokenDto> signin(@RequestBody @Valid SigninReqDto reqDto, HttpServletResponse response) {
         log.info("로그인 요청: {}", reqDto);
-        TokenDto tokenDto = memberService.signin(reqDto);
+        TokenDto tokenDto = memberService.signin(reqDto, response);
         log.info("로그인 성공: {}", tokenDto);
         return new SuccessResponse<>(tokenDto);
     }

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/TokenDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/TokenDto.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 @Builder
 public record TokenDto(
         String accessToken,
-        String refreshToken,
         Long memberId,
         String username,
         RoleType roleType

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberService.java
@@ -6,13 +6,14 @@ import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberUpdateResDto;
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MemberService {
     void signup(SignupReqDto reqDto);
 
-    TokenDto signin(SigninReqDto reqDto);
+    TokenDto signin(SigninReqDto reqDto, HttpServletResponse response);
 
     void resetPassword(ResetReqDto reqDto);
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -120,7 +120,6 @@ public class MemberServiceImpl implements MemberService {
 
         return TokenDto.builder()
                 .accessToken(accessToken)
-                .refreshToken(refreshToken)
                 .memberId(member.getId())
                 .username(member.getUsername())
                 .roleType(member.getRole())

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/MemberServiceImpl.java
@@ -25,6 +25,7 @@ import com.souf.soufwebsite.global.common.category.service.CategoryService;
 import com.souf.soufwebsite.global.email.EmailService;
 import com.souf.soufwebsite.global.jwt.JwtService;
 import com.souf.soufwebsite.global.util.SecurityUtils;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -38,6 +39,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -100,7 +102,7 @@ public class MemberServiceImpl implements MemberService {
 
     //로그인
     @Override
-    public TokenDto signin(SigninReqDto reqDto) {
+    public TokenDto signin(SigninReqDto reqDto, HttpServletResponse response) {
 
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(reqDto.email(), reqDto.password());
 
@@ -112,8 +114,9 @@ public class MemberServiceImpl implements MemberService {
 
         String accessToken = jwtService.createAccessToken(member);
         String refreshToken = jwtService.createRefreshToken(member);
-
         redisTemplate.opsForValue().set("refresh:" + email, refreshToken, jwtService.getExpiration(refreshToken), TimeUnit.MILLISECONDS);
+
+        jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
 
         return TokenDto.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/souf/soufwebsite/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/souf/soufwebsite/global/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.souf.soufwebsite.global.jwt;
 
 import com.souf.soufwebsite.domain.member.entity.Member;
-import com.souf.soufwebsite.domain.member.entity.RoleType;
 import com.souf.soufwebsite.domain.member.reposiotry.MemberRepository;
 import com.souf.soufwebsite.global.security.UserDetailsImpl;
 import jakarta.servlet.FilterChain;
@@ -10,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -127,7 +125,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.info("AccessToken 재발급: {}", newAccessToken);
             return newAccessToken;
         }
-
         throw new IllegalArgumentException("유효하지 않은 refresh token");
     }
 }

--- a/src/main/java/com/souf/soufwebsite/global/jwt/JwtService.java
+++ b/src/main/java/com/souf/soufwebsite/global/jwt/JwtService.java
@@ -1,7 +1,6 @@
 package com.souf.soufwebsite.global.jwt;
 
 import com.souf.soufwebsite.domain.member.entity.Member;
-import com.souf.soufwebsite.domain.member.entity.RoleType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -13,7 +12,6 @@ public interface JwtService {
 
     String createRefreshToken(Member member);
 
-
     Optional<String> extractAccessToken(HttpServletRequest request);
 
     Optional<String> extractRefreshToken(HttpServletRequest request);
@@ -22,8 +20,11 @@ public interface JwtService {
 
     boolean isTokenValid(String token);
 
-
     long getExpiration(String token);
 
     void sendAccessToken(HttpServletResponse response, String newAccessToken);
+
+    void sendAccessAndRefreshToken(HttpServletResponse response,
+                                          String accessToken,
+                                          String refreshToken);
 }


### PR DESCRIPTION
## 개요
refreshToken을 쿠키에 저장 후, accessToken이 만료될 시 재발급 후 헤더에 담아서 전달

## 진행한 이슈
- close #89 

## 구현 내용
![image](https://github.com/user-attachments/assets/6cfb8ab4-f4a7-418e-b18a-83b6900a21d9)\
쿠키에 저장


## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
