### PR TITLE
[Fix] 채팅별 아이디 반환

### DIFF
--- a/.github/workflows/test-CI-CD.yml
+++ b/.github/workflows/test-CI-CD.yml
@@ -97,8 +97,8 @@ jobs:
             cd ~/deploy
             docker pull ${{ secrets.DOCKER_USERNAME }}/github-actions-iamsouf
             
-            docker compose -f docker-compose-test.yml --env-file ./souf.env down
+            docker-compose -f docker-compose-test.yml --env-file ./souf.env down
             
-            docker compose -f docker-compose-test.yml --env-file ./souf.env up -d
+            docker-compose -f docker-compose-test.yml --env-file ./souf.env up -d
 
 

--- a/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatController.java
@@ -3,6 +3,7 @@ package com.souf.soufwebsite.domain.chat.controller;
 import com.souf.soufwebsite.domain.chat.dto.ChatMessageReqDto;
 import com.souf.soufwebsite.domain.chat.dto.ChatMessageResDto;
 import com.souf.soufwebsite.domain.chat.dto.MessageType;
+import com.souf.soufwebsite.domain.chat.entity.ChatMessage;
 import com.souf.soufwebsite.domain.chat.entity.ChatRoom;
 import com.souf.soufwebsite.domain.chat.service.ChatMessageService;
 import com.souf.soufwebsite.domain.chat.service.ChatRoomService;
@@ -49,7 +50,7 @@ public class ChatController {
             throw new AccessDeniedException("채팅방에 참여하지 않은 유저입니다.");
         }
 
-        chatMessageService.saveMessage(room, sender, request.content(), request.type());
+        ChatMessage saved = chatMessageService.saveMessage(room, sender, request.content(), request.type());
 
         String urlPrefix = "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/";
         String finalContent = (request.type().equals(MessageType.IMAGE) || request.type().equals(MessageType.FILE))
@@ -58,14 +59,13 @@ public class ChatController {
 
         ChatMessageResDto response = new ChatMessageResDto(
                 room.getId(),
+                saved.getId(),
                 sender.getNickname(),
                 request.type(),
                 finalContent,
                 false,
                 LocalDateTime.now()
         );
-
         messagingTemplate.convertAndSend("/topic/chatroom." + room.getId(), response);
-
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatFileApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatFileApiSpecification.java
@@ -21,7 +21,7 @@ public interface ChatFileApiSpecification {
     ResponseEntity<List<PresignedUrlResDto>> uploadChatFile(
             @RequestBody ChatFileReqDto reqDto);
 
-    @Operation(summary = "해당 채팅 관련 파일 정보 저장\", description = \"제공된 presignedUrl을 통해 업로드한 파일의 정보를 DB에도 반영할 수 있도록 서버에게 파일 정보를 보냅니다.")
+    @Operation(summary = "해당 채팅 관련 파일 정보 저장", description = "제공된 presignedUrl을 통해 업로드한 파일의 정보를 DB에도 반영할 수 있도록 서버에게 파일 정보를 보냅니다.")
     @PostMapping
     SuccessResponse uploadMetadata(
             @Valid @RequestBody MediaReqDto mediaReqDto);

--- a/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatRoomController.java
@@ -69,6 +69,7 @@ public class ChatRoomController implements ChatRoomApiSpecificaton {
         List<ChatMessageResDto> result = messages.stream()
                 .map(msg -> new ChatMessageResDto(
                         roomId,
+                        msg.getId(),
                         msg.getSender().getNickname(),
                         msg.getType(),
                         msg.getContent(),

--- a/src/main/java/com/souf/soufwebsite/domain/chat/dto/ChatMessageResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/dto/ChatMessageResDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 public record ChatMessageResDto(
         Long roomId,
+        Long chatId,
         String sender,
         MessageType type,
         String content,

--- a/src/main/java/com/souf/soufwebsite/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/service/ChatMessageService.java
@@ -23,7 +23,7 @@ public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
     private final FileService fileService;
 
-    public void saveMessage(ChatRoom room, Member sender, String content, MessageType type) {
+    public ChatMessage saveMessage(ChatRoom room, Member sender, String content, MessageType type) {
         ChatMessage message = ChatMessage.builder()
                 .chatRoom(room)
                 .sender(sender)
@@ -31,7 +31,7 @@ public class ChatMessageService {
                 .type(type)
                 .build();
 
-        chatMessageRepository.save(message);
+        return chatMessageRepository.save(message);
     }
 
     public List<ChatMessage> getMessages(Long chatRoomId) {


### PR DESCRIPTION
## 개요
채팅 시스템에서 이미지나 기타 파일을 전송하기 위해 채팅 생성 시 아이디 값을 반환하도록 수정합니다.

## 진행한 이슈
- close #116

## 구현 내용
![image](https://github.com/user-attachments/assets/82419469-dafa-4f13-8927-b8a13683879b)

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
