### PR TITLE
Fix: 동영상 썸네일 저장하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,12 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("org.opensearch.client:opensearch-rest-client:2.19.0")
 
+    // AWS ECS
+    implementation 'software.amazon.awssdk:ecs'
+
+    // AWS SQS
+    implementation 'io.awspring.cloud:spring-cloud-aws-messaging:2.4.2'
+
     // slack
     implementation("com.slack.api:bolt:1.18.0")
     implementation("com.slack.api:bolt-servlet:1.18.0")

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     // AWS ECS
     implementation 'software.amazon.awssdk:ecs'
 
-    // AWS SQS
+    // SQS
     implementation 'io.awspring.cloud:spring-cloud-aws-messaging:2.4.2'
 
     // slack

--- a/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatFileController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatFileController.java
@@ -4,7 +4,7 @@ import com.souf.soufwebsite.domain.chat.dto.ChatFileReqDto;
 import com.souf.soufwebsite.domain.chat.service.ChatMessageService;
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.domain.file.dto.PresignedUrlResDto;
-import com.souf.soufwebsite.domain.file.dto.video.VideoResDto;
+import com.souf.soufwebsite.domain.file.dto.video.VideoDto;
 import com.souf.soufwebsite.domain.file.entity.PostType;
 import com.souf.soufwebsite.domain.file.service.FileService;
 import com.souf.soufwebsite.global.success.SuccessResponse;
@@ -42,8 +42,8 @@ public class ChatFileController implements ChatFileApiSpecification{
     }
 
     @PostMapping("/video-upload")
-    public ResponseEntity<VideoResDto> uploadChatVideoFile(@RequestBody ChatFileReqDto reqDto) {
-        VideoResDto resDto = fileService.configVideoUploadInitiation(reqDto.originalFileNames(), PostType.CHAT);
+    public ResponseEntity<VideoDto> uploadChatVideoFile(@RequestBody ChatFileReqDto reqDto) {
+        VideoDto resDto = fileService.configVideoUploadInitiation(reqDto.originalFileNames(), PostType.CHAT);
         return ResponseEntity.ok(resDto);
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedResDto.java
@@ -1,14 +1,14 @@
 package com.souf.soufwebsite.domain.feed.dto;
 
 import com.souf.soufwebsite.domain.file.dto.PresignedUrlResDto;
-import com.souf.soufwebsite.domain.file.dto.video.VideoResDto;
+import com.souf.soufwebsite.domain.file.dto.video.VideoDto;
 
 import java.util.List;
 
 public record FeedResDto(
         Long feedId,
         List<PresignedUrlResDto> dtoList,
-        VideoResDto videoResDto
+        VideoDto videoDto
 ) {
 
 }

--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
@@ -8,7 +8,7 @@ import com.souf.soufwebsite.domain.feed.exception.NotValidAuthenticationExceptio
 import com.souf.soufwebsite.domain.feed.repository.FeedRepository;
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.domain.file.dto.PresignedUrlResDto;
-import com.souf.soufwebsite.domain.file.dto.video.VideoResDto;
+import com.souf.soufwebsite.domain.file.dto.video.VideoDto;
 import com.souf.soufwebsite.domain.file.entity.Media;
 import com.souf.soufwebsite.domain.file.entity.PostType;
 import com.souf.soufwebsite.domain.file.service.FileService;
@@ -75,20 +75,20 @@ public class FeedServiceImpl implements FeedService {
         redisUtil.set(feedViewKey);
 
         List<PresignedUrlResDto> presignedUrlResDtos = fileService.generatePresignedUrl("feed", reqDto.originalFileNames());
-        VideoResDto videoResDto = fileService.configVideoUploadInitiation(reqDto.originalFileNames(), PostType.FEED);
+        VideoDto videoDto = fileService.configVideoUploadInitiation(reqDto.originalFileNames(), PostType.FEED);
 
 
         String slackMsg = member.getNickname() + " 님이 피드를 작성하였습니다.\n" +
                 "https://www.souf.co.kr/feedDetails/" + feed.getId().toString() + "\n" +
                 member.getNickname() + " 님을 다같이 환영해보아요:)";
         slackService.sendSlackMessage(slackMsg, "post");
-        return new FeedResDto(feed.getId(), presignedUrlResDtos, videoResDto);
+        return new FeedResDto(feed.getId(), presignedUrlResDtos, videoDto);
     }
 
     @Override
     public void uploadFeedMedia(MediaReqDto mediaReqDto) {
         Feed feed = findIfFeedExist(mediaReqDto.postId());
-        List<Media> mediaList = fileService.uploadMetadata(mediaReqDto, PostType.FEED, feed.getId());
+        fileService.uploadMetadata(mediaReqDto, PostType.FEED, feed.getId());
     }
 
     @Transactional(readOnly = true)
@@ -130,7 +130,7 @@ public class FeedServiceImpl implements FeedService {
         updatedRemainingUrls(reqDto, feed);
 
         List<PresignedUrlResDto> presignedUrlResDtos = fileService.generatePresignedUrl("feed", reqDto.originalFileNames());
-        VideoResDto videoResDto = fileService.configVideoUploadInitiation(reqDto.originalFileNames(), PostType.FEED);
+        VideoDto videoDto = fileService.configVideoUploadInitiation(reqDto.originalFileNames(), PostType.FEED);
 
         feed.clearCategories();
         injectCategories(reqDto, feed);
@@ -142,7 +142,7 @@ public class FeedServiceImpl implements FeedService {
                 feed
         );
 
-        return new FeedResDto(feed.getId(), presignedUrlResDtos, videoResDto);
+        return new FeedResDto(feed.getId(), presignedUrlResDtos, videoDto);
     }
 
     @Override

--- a/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaResDto.java
@@ -1,6 +1,11 @@
 package com.souf.soufwebsite.domain.file.dto;
 
 import com.souf.soufwebsite.domain.file.entity.Media;
+import com.souf.soufwebsite.domain.file.entity.MediaType;
+
+import java.util.List;
+
+import static com.souf.soufwebsite.domain.file.entity.MediaType.*;
 
 public record MediaResDto(
         String fileName,
@@ -8,9 +13,15 @@ public record MediaResDto(
 ) {
 
     public static MediaResDto fromFeedDetail(Media media){
+        List<MediaType> mediaTypes = List.of(new MediaType[]{MP4, MOV, AVI, MKV, WEBM, FLV, QUICKTIME});
+        String originalUrl = media.getOriginalUrl();
+        if(mediaTypes.contains(media.getMediaType())){
+            originalUrl = media.getThumbnailUrl();
+        }
+
         return new MediaResDto(
                 media.getFileName(),
-                media.getOriginalUrl()
+                originalUrl
         );
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/file/dto/video/VideoDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/dto/video/VideoDto.java
@@ -1,6 +1,6 @@
 package com.souf.soufwebsite.domain.file.dto.video;
 
-public record VideoResDto(
+public record VideoDto(
         String uploadId,
         String fileName
 ) {

--- a/src/main/java/com/souf/soufwebsite/domain/file/dto/video/VideoUploadCompletedDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/dto/video/VideoUploadCompletedDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record VideoUploadCompletedDto(
         String uploadId,
         String fileUrl,
-        List<S3UploadPartsDetailDto> parts
+        List<S3UploadPartsDetailDto> parts,
+        String type
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/file/dto/video/VideoUploadCompletedDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/dto/video/VideoUploadCompletedDto.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record VideoUploadCompletedDto(
         String uploadId,
-        String fileName,
+        String fileUrl,
         List<S3UploadPartsDetailDto> parts
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/file/entity/Media.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/entity/Media.java
@@ -23,9 +23,8 @@ public class Media extends BaseEntity {
     @Column(nullable = false)
     private String originalUrl;
 
-    // @NotNull
-    // @Column
-    // private String thumbnailUrl;
+     @Column
+     private String thumbnailUrl;
 
     // @NotNull
     // private String detailThumbnailUrl;
@@ -51,5 +50,9 @@ public class Media extends BaseEntity {
                 .postType(postType)
                 .postId(postId)
                 .build();
+    }
+
+    public void addThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/file/repository/MediaRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/repository/MediaRepository.java
@@ -18,4 +18,6 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
     @Modifying
     @Query("delete from Media m where m.postType = :postType and m.postId = :postId")
     void deleteAllByPostTypeAndPostId(PostType postType, Long postId);
+
+    Media findByOriginalUrlContains(String originalUrl);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/file/service/FileService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/service/FileService.java
@@ -2,7 +2,7 @@ package com.souf.soufwebsite.domain.file.service;
 
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.domain.file.dto.PresignedUrlResDto;
-import com.souf.soufwebsite.domain.file.dto.video.VideoResDto;
+import com.souf.soufwebsite.domain.file.dto.video.VideoDto;
 import com.souf.soufwebsite.domain.file.entity.Media;
 import com.souf.soufwebsite.domain.file.entity.MediaType;
 import com.souf.soufwebsite.domain.file.entity.PostType;
@@ -25,7 +25,7 @@ public class FileService {
 
     private final Set<String> videoExtensions = Set.of("mp4", "mov", "avi", "mkv", "webm", "flv");
 
-    public VideoResDto configVideoUploadInitiation(List<String> originalFilenames, PostType type) {
+    public VideoDto configVideoUploadInitiation(List<String> originalFilenames, PostType type) {
         List<String> videoFiles = originalFilenames.stream()
                 .filter(f -> videoExtensions.contains(extractExtension(f).toLowerCase()))
                 .toList();

--- a/src/main/java/com/souf/soufwebsite/domain/file/service/S3UploaderService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/service/S3UploaderService.java
@@ -3,8 +3,9 @@ package com.souf.soufwebsite.domain.file.service;
 import com.souf.soufwebsite.domain.file.dto.PresignedUrlResDto;
 import com.souf.soufwebsite.domain.file.dto.video.S3UploadPartsDetailDto;
 import com.souf.soufwebsite.domain.file.dto.video.S3VideoUploadSignedUrlReqDto;
-import com.souf.soufwebsite.domain.file.dto.video.VideoResDto;
+import com.souf.soufwebsite.domain.file.dto.video.VideoDto;
 import com.souf.soufwebsite.domain.file.dto.video.VideoUploadCompletedDto;
+import com.souf.soufwebsite.global.ecs.ECSService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +31,7 @@ public class S3UploaderService {
 
     private final S3Client s3Client;
     private final S3Presigner s3Presigner;
+    private final ECSService ecsService;
 
     private static final String videoFolder = "video";
 
@@ -39,7 +41,7 @@ public class S3UploaderService {
     /* ------------------------------------- VIDEO ----------------------------------------------*/
 
     // 비디오 업로드 전 세팅 단계
-    public VideoResDto initiateUpload(String prefix, String originalFilename) {
+    public VideoDto initiateUpload(String prefix, String originalFilename) {
         String ext = extractExtension(originalFilename);
         String filename = prefix + "/" + videoFolder + "/" + UUID.randomUUID() + "." + ext;
 
@@ -53,7 +55,7 @@ public class S3UploaderService {
 
         CreateMultipartUploadResponse response = s3Client.createMultipartUpload(createMultipartUploadRequest);
 
-        return new VideoResDto(response.uploadId(), filename);
+        return new VideoDto(response.uploadId(), filename);
     }
 
     public PresignedUrlResDto getVideoUploadSignedUrl(S3VideoUploadSignedUrlReqDto reqDto) {
@@ -88,7 +90,7 @@ public class S3UploaderService {
                 .parts(completedPartList)
                 .build();
 
-        String fileName = dtos.fileName();
+        String fileName = dtos.fileUrl();
         CompleteMultipartUploadRequest completeMultipartUploadRequest = CompleteMultipartUploadRequest.builder()
                 .bucket(bucketName)
                 .key(fileName)
@@ -96,7 +98,9 @@ public class S3UploaderService {
                 .multipartUpload(completedMultipartUpload)
                 .build();
 
-        CompleteMultipartUploadResponse response = s3Client.completeMultipartUpload(completeMultipartUploadRequest);
+        s3Client.completeMultipartUpload(completeMultipartUploadRequest);
+
+        ecsService.triggerThumbnailJob(dtos.fileUrl(), "feed/video/" + dtos.fileUrl());
     }
 
     /* -------------------------------------- image ---------------------------------------------- */

--- a/src/main/java/com/souf/soufwebsite/domain/file/service/S3UploaderService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/service/S3UploaderService.java
@@ -100,7 +100,7 @@ public class S3UploaderService {
 
         s3Client.completeMultipartUpload(completeMultipartUploadRequest);
 
-        ecsService.triggerThumbnailJob(dtos.fileUrl(), "feed/video/" + dtos.fileUrl());
+        ecsService.triggerThumbnailJob(dtos.fileUrl(), dtos.type() + "/video/" + dtos.fileUrl());
     }
 
     /* -------------------------------------- image ---------------------------------------------- */

--- a/src/main/java/com/souf/soufwebsite/global/common/mail/SesMailService.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/mail/SesMailService.java
@@ -28,6 +28,7 @@ public class SesMailService {
                     createSendTemplatedEmailRequest(to, "SouFEmailVerification", data);
 
             emailService.sendTemplatedEmail(request);
+            log.info("인증번호가 성공적으로 전송되었습니다!");
         } catch (Exception e) {
             throw new RuntimeException("인증번호 전송 실패", e);
         }

--- a/src/main/java/com/souf/soufwebsite/global/config/AWSConfig.java
+++ b/src/main/java/com/souf/soufwebsite/global/config/AWSConfig.java
@@ -10,8 +10,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
@@ -53,6 +55,14 @@ public class AWSConfig {
         return AmazonSimpleEmailServiceClientBuilder.standard()
                 .withCredentials(credentialsProvider)
                 .withRegion(Regions.AP_NORTHEAST_2)
+                .build();
+    }
+
+    @Bean
+    public EcsClient ecsClient() {
+        return EcsClient.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 }

--- a/src/main/java/com/souf/soufwebsite/global/config/RedisConfig.java
+++ b/src/main/java/com/souf/soufwebsite/global/config/RedisConfig.java
@@ -49,11 +49,14 @@ public class RedisConfig {
         return redisTemplate;
     }
 
-    @Bean
+    @Bean(destroyMethod = "shutdown")
     public RedissonClient redissonClient() {
         Config config = new Config();
-        config.useSingleServer().setAddress(REDISSON_PREFIX + redisProperties.getHost() + ":" + redisProperties.getPort());
-        config.useSingleServer().setPassword(redisProperties.getPassword());
+        config.useSingleServer()
+                .setAddress(REDISSON_PREFIX + redisProperties.getHost() + ":" + redisProperties.getPort())
+                .setPassword(redisProperties.getPassword())
+                .setConnectionPoolSize(25)
+                .setConnectionMinimumIdleSize(15);
 
         return Redisson.create(config);
     }

--- a/src/main/java/com/souf/soufwebsite/global/ecs/ECSService.java
+++ b/src/main/java/com/souf/soufwebsite/global/ecs/ECSService.java
@@ -1,0 +1,47 @@
+package com.souf.soufwebsite.global.ecs;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.*;
+
+@Service
+@RequiredArgsConstructor
+public class ECSService {
+
+    private final EcsClient ecsClient;
+
+    @Value("${cloud.aws.ecs.cluster}")
+    private String clusterName;
+
+    @Value("${cloud.aws.ecs.task-definition}")
+    private String taskDefinition;
+
+    @Value("${cloud.aws.ecs.subnet}")
+    private String subnet;
+
+    @Value("${cloud.aws.ecs.security-group}")
+    private String securityGroup;
+
+    public void triggerThumbnailJob(String videoUrl, String prefix){
+        ecsClient.runTask(r -> r
+                .cluster(clusterName)
+                .taskDefinition(taskDefinition)
+                .launchType(LaunchType.FARGATE)
+                .overrides(TaskOverride.builder()
+                        .containerOverrides(ContainerOverride.builder()
+                                .name("ffmpeg-container-souf")
+                                .command(prefix, videoUrl)
+                                .build())
+                        .build())
+                .networkConfiguration(NetworkConfiguration.builder()
+                        .awsvpcConfiguration(AwsVpcConfiguration.builder()
+                                .subnets(subnet)
+                                .assignPublicIp(AssignPublicIp.ENABLED)
+                                .securityGroups(securityGroup)
+                                .build())
+                        .build())
+        );
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/global/ecs/ECSService.java
+++ b/src/main/java/com/souf/soufwebsite/global/ecs/ECSService.java
@@ -31,7 +31,7 @@ public class ECSService {
                 .launchType(LaunchType.FARGATE)
                 .overrides(TaskOverride.builder()
                         .containerOverrides(ContainerOverride.builder()
-                                .name("ffmpeg-container-souf")
+                                .name("souf-ffmpeg-container-souf")
                                 .command(prefix, videoUrl)
                                 .build())
                         .build())

--- a/src/main/java/com/souf/soufwebsite/global/sqs/ThumbnailEventListener.java
+++ b/src/main/java/com/souf/soufwebsite/global/sqs/ThumbnailEventListener.java
@@ -1,0 +1,27 @@
+package com.souf.soufwebsite.global.sqs;
+
+import com.amazonaws.services.s3.event.S3EventNotification;
+import com.souf.soufwebsite.domain.file.entity.Media;
+import com.souf.soufwebsite.domain.file.repository.MediaRepository;
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ThumbnailEventListener {
+
+    private final MediaRepository mediaRepository;
+
+    @SqsListener("souf-thumbnail-created-queue")
+    public void handleThumbnailEvent(String message) {
+        S3EventNotification notification = S3EventNotification.parseJson(message);
+        for(S3EventNotification.S3EventNotificationRecord record : notification.getRecords()) {
+            String s3Key = record.getS3().getObject().getKey();
+            String urlType = s3Key.substring(s3Key.lastIndexOf("/") + 1, s3Key.lastIndexOf("."));
+
+            Media media = mediaRepository.findByOriginalUrlContains(urlType);
+            media.addThumbnailUrl(record.getS3().getObject().getKey());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,13 @@ cloud:
       secret-key: ${AWS_SECRET_KEY}
     s3:
       bucket: ${BUCKET_NAME}
+    ecs:
+      cluster: asdfads
+      task-definition: asdfdas
+      subnet: asdfdsa
+      security-group: asdfdas
+    messaging:
+      enabled: true
 
 websocket:
   relay:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,10 +45,10 @@ cloud:
     s3:
       bucket: ${BUCKET_NAME}
     ecs:
-      cluster: asdfads
-      task-definition: asdfdas
-      subnet: asdfdsa
-      security-group: asdfdas
+      cluster: ${ECS_CLUSTER}
+      task-definition: ${ECS_TASK_DEFINITION}
+      subnet: ${ECS_SUBNET}
+      security-group: ${SECURITY_GROUP}
     messaging:
       enabled: true
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- close #149 

## 구현 내용
- [x] 이슈에 기입된 사항들을 모두 충족했나요?
 ecs, sqs를 연동하여 동영상 업로드 시 썸네일을 추출하여 저장하도록 구현

## 참고 자료
플로우는 다음과 같습니다.
1. 동영상를 업로드 후 완료 API 호출
2. 호출 시 ecs가 트리거 되어 ffmeg를 통해 썸네일을 추출 후 s3에 thumbnail 저장
3. 저장 시 S3가 sqs에 이벤트 알림을 보내 해당 Entity에 thumbnail URL 저장

[업로드 완료 API 후 ECS 호출]
<img width="887" height="575" alt="image" src="https://github.com/user-attachments/assets/d4eb7506-8e9b-4fc1-bf3e-ad6abb61611a" />

[ECS 작업]
<img width="780" height="448" alt="image" src="https://github.com/user-attachments/assets/e1ad099e-8d47-4e07-9c27-8ce731070a98" />

[SQS로부터 받은 url을 Media에 저장]
<img width="860" height="248" alt="image" src="https://github.com/user-attachments/assets/b97881a1-7414-4212-a237-6579f9ea2d46" />

