### PR TITLE
[Fix] getFeeds currentUser 삭제

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
@@ -195,7 +195,7 @@ public class FeedServiceImpl implements FeedService {
     @Transactional(readOnly = true)
     @Override
     public Slice<FeedDetailResDto> getFeeds(Long first, Pageable pageable) {
-        Member currentUser = getCurrentUser();
+//        Member currentUser = getCurrentUser();
 
         Slice<Feed> feeds = feedRepository.findByFirstCategoryOrderByCreatedTimeDesc(first, pageable);
 
@@ -208,10 +208,11 @@ public class FeedServiceImpl implements FeedService {
                     String profileImageUrl = fileService.getMediaUrl(PostType.PROFILE, member.getId());
 
                     Long likedCount = likedFeedRepository.countByFeedId(feed.getId()).orElse(0L);
-                    Boolean liked = getLiked(currentUser.getId(), feed.getId());
+//                    Boolean liked = getLiked(currentUser.getId(), feed.getId());
                     Long commentCount = commentRepository.countByFeed(feed).orElse(0L);
 
-                    return FeedDetailResDto.from(feed.getMember(), profileImageUrl, feed, viewCountFromRedis, likedCount, liked, commentCount, mediaList);
+//                    return FeedDetailResDto.from(feed.getMember(), profileImageUrl, feed, viewCountFromRedis, likedCount, liked, commentCount, mediaList);
+                    return FeedDetailResDto.from(feed.getMember(), profileImageUrl, feed, viewCountFromRedis, likedCount, false, commentCount, mediaList);
                 }
         );
     }


### PR DESCRIPTION
## 개요
getFeeds 호출 시 좋아요 여부를 확인하기 위해 currentUser를 조회하는데, 비로그인 시 getFeeds를 호출하지 못하는 오류가 있었습니다.
우선 주석처리 해두었고, 로그인한 경우와 비로그인 경우의 분기점을 설정해야 할 것 같습니다.

## 진행한 이슈
- close #174 

## 구현 내용
- <img width="1234" height="628" alt="image" src="https://github.com/user-attachments/assets/b3d67ff1-3b08-4af4-baaa-466ae0062f58" />

## 참고 자료
