### PR TITLE
[Fix] 소셜 로그인 카테고리 매핑 기능 추가 및 개인약관 동의 추가여부 추가

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/dto/SocialCompleteSignupReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/dto/SocialCompleteSignupReqDto.java
@@ -1,9 +1,26 @@
 package com.souf.soufwebsite.domain.socialAccount.dto;
 
+import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.util.List;
 
 public record SocialCompleteSignupReqDto(
-        String registrationToken,         // 로그인 단계에서 받은 임시 토큰
-        String nickname,                  // 사용자가 최종 선택한 닉네임
-        List<Long> categoryIds            // 선택한 카테고리(예시)
+        @NotBlank @Size(min = 2, max = 20) String nickname,
+
+        @Size(max = 3, message = "카테고리는 최대 3개까지 선택 가능합니다.")
+        List<@Valid @NotNull CategoryDto> categoryDtos,
+
+        @NotNull
+        @Schema(description = "개인정보 동의서 확인 여부", example = "true여야 합니다.")
+        Boolean isPersonalInfoAgreed,
+
+        @Schema(description = "마케팅 동의 확인 여부", example = "true or false")
+        Boolean isMarketingAgreed,
+
+        @NotBlank String registrationToken
 ) {}


### PR DESCRIPTION
## 개요
카카오 계정 회원가입 시 카테고리 매핑을 추가하였고, 
개인약관, 마케팅 동의 여부 추가하였습니다.

## 진행한 이슈
- close #178 

## 구현 내용
- [ ] 이슈에 기입된 사항들을 모두 충족했나요?
 상세히 구현한 내용들을 기입해 주세요!

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
