### PR TITLE
fix: 회원 탈퇴 시 멤버 객체 삭제 후, 일주일 간 재가입이 안되도록 수정

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/member/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/exception/ErrorType.java
@@ -19,7 +19,8 @@ public enum ErrorType {
 
     // ----------------------------------- Agreement -------------------------------
 
-    NOT_AGREED_PERSONAL_INFO(404, "개인정보 동의서에 동의하지 않았습니다.");
+    NOT_AGREED_PERSONAL_INFO(404, "개인정보 동의서에 동의하지 않았습니다."),
+    NOT_ALLOW_SIGNUP(404, "해당 탈퇴한 이메일은 탈퇴 시점으로부터 일주일 이내에 재가입이 불가능합니다.");
 
 
     private final int code;

--- a/src/main/java/com/souf/soufwebsite/domain/member/exception/NotAllowedSignupException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/exception/NotAllowedSignupException.java
@@ -1,0 +1,11 @@
+package com.souf.soufwebsite.domain.member.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.member.exception.ErrorType.NOT_ALLOW_SIGNUP;
+
+public class NotAllowedSignupException extends BaseErrorException {
+    public NotAllowedSignupException() {
+        super(NOT_ALLOW_SIGNUP.getCode(), NOT_ALLOW_SIGNUP.getMessage());
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- close #173 

## 구현 내용
- [x] 이슈에 기입된 사항들을 모두 충족했나요?
 가입한 회원이 탈퇴를 시도한 후에 동일한 이메일로 재가입 시도 시, 의도적인 재가입 방지를 위해 일주일 간 이메일 사용 금지를 시킵니다.

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
