### PR TITLE
[FIX] 카카오 소셜로그인 오류

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/dto/SocialLoginResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/dto/SocialLoginResDto.java
@@ -4,7 +4,21 @@ import com.souf.soufwebsite.domain.member.dto.TokenDto;
 
 public record SocialLoginResDto(
         boolean requiresSignup,          // 온보딩 필요 여부
+        boolean requiresLink,            // 계정 연동 필요 여부
+        String registrationToken,
         TokenDto token,                  // 로그인 성공 시만 채움
-        String registrationToken,        // 온보딩 필요 시만 채움
+        String message,        // 온보딩 필요 시만 채움
         SocialPrefill prefill            // 프리필용 (이메일/닉네임 후보/프로필 등)
-) {}
+) {
+    public static SocialLoginResDto loggedIn(TokenDto token, SocialPrefill prefill) {
+        return new SocialLoginResDto(false, false, null, token, null, prefill);
+    }
+
+    public static SocialLoginResDto requiresSignup(String message, SocialPrefill prefill) {
+        return new SocialLoginResDto(false, true, null, null, message, prefill);
+    }
+
+    public static SocialLoginResDto requiresLink(String registrationToken, SocialPrefill prefill) {
+        return new SocialLoginResDto(true, false, registrationToken, null, null, prefill);
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/service/SocialAccountService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/service/SocialAccountService.java
@@ -96,7 +96,7 @@ public class SocialAccountService {
         if (account != null) {
             Member member = account.getMember();
             TokenDto token = issueTokens(member); // 아래 헬퍼 참고
-            return SocialLoginResDto.loggedIn(token, /*prefill*/ new SocialPrefill(
+            return SocialLoginResDto.loggedIn(token, new SocialPrefill(
                     member.getEmail(), member.getUsername(), info.profileImageUrl(), request.provider().name()
             ));
         }

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/service/SocialAccountService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/service/SocialAccountService.java
@@ -96,9 +96,17 @@ public class SocialAccountService {
         if (account != null) {
             Member member = account.getMember();
             TokenDto token = issueTokens(member); // 아래 헬퍼 참고
-            return new SocialLoginResDto(false, token, null,
-                    new SocialPrefill(member.getEmail(), member.getUsername(),
-                            info.profileImageUrl(), request.provider().name()));
+            return SocialLoginResDto.loggedIn(token, /*prefill*/ new SocialPrefill(
+                    member.getEmail(), member.getUsername(), info.profileImageUrl(), request.provider().name()
+            ));
+        }
+
+        // 1-2) 소셜 연결은 없고, 이메일이 있고, 그 이메일로 기존 회원이 있으면 → 연결 필요
+        if (info.email() != null && memberRepository.findByEmail(info.email()).isPresent()) {
+            return SocialLoginResDto.requiresLink(
+                    /* message */ "이미 가입된 이메일입니다. 기존 계정으로 로그인 후 '마이페이지 > 소셜 연결'에서 연동해 주세요.",
+                    /* prefill */ new SocialPrefill(info.email(), info.name(), info.profileImageUrl(), request.provider().name())
+            );
         }
 
         // 2) 연결이 없으면 → 온보딩 필요 (DB 생성 금지!)
@@ -116,12 +124,9 @@ public class SocialAccountService {
         redisTemplate.opsForHash().putAll("social:reg:" + registrationToken, payload);
         redisTemplate.expire("social:reg:" + registrationToken, java.time.Duration.ofMinutes(10));
 
-        return new SocialLoginResDto(
-                true,                      // requiresSignup
-                null,                      // token 없음
-                registrationToken,         // 프론트가 들고 온보딩 완료 호출에 사용
-                new SocialPrefill(info.email(), info.name(),
-                        info.profileImageUrl(), request.provider().name())
+        return SocialLoginResDto.requiresSignup(
+                registrationToken,
+                new SocialPrefill(info.email(), info.name(), info.profileImageUrl(), request.provider().name())
         );
     }
 


### PR DESCRIPTION
## 개요
소셜로그인을 통해 회원가입을 시도할 때, 해당 메일의 유저가 있으면 회원가입 실패 안내를 반환합니다.
로그인 화면으로 이동 -> 마이페이지에서 소셜 로그인 연결 흐름으로 진행될 예정이며, 기존 계정에 소셜로그인 정보를 연결하는 api는 추가 개발할 예정입니다.

## 진행한 이슈
- close #197 

## 구현 내용
- <img width="1144" height="351" alt="image" src="https://github.com/user-attachments/assets/9c2f0063-f3f8-4bfa-85b5-fc2a24013f80" />


## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
