### PR TITLE
[FIX] 소셜 로그인 시도 시 해당 이메일의 유저가 있을 시 에러 처리

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/DuplicateEmailException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/DuplicateEmailException.java
@@ -1,0 +1,9 @@
+package com.souf.soufwebsite.domain.socialAccount.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.socialAccount.exception.ErrorType.DUPLICATE_EMAIL;
+
+public class DuplicateEmailException extends BaseErrorException {
+    public DuplicateEmailException(){super(DUPLICATE_EMAIL.getCode(), DUPLICATE_EMAIL.getMessage());}
+}

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/ErrorType.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorType {
 
-    NOT_VALID_AUTHENTICATION(403, "해당 소셜 계정으로 로그인할 수 없습니다");
+    NOT_VALID_AUTHENTICATION(403, "해당 소셜 계정으로 로그인할 수 없습니다"),
+    DUPLICATE_EMAIL(409, "이미 가입된 이메일입니다. 마이페이지에서 소셜 계정을 연결해주세요.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/service/SocialAccountService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/service/SocialAccountService.java
@@ -14,6 +14,7 @@ import com.souf.soufwebsite.domain.socialAccount.SocialProvider;
 import com.souf.soufwebsite.domain.socialAccount.client.SocialApiClient;
 import com.souf.soufwebsite.domain.socialAccount.dto.*;
 import com.souf.soufwebsite.domain.socialAccount.entity.SocialAccount;
+import com.souf.soufwebsite.domain.socialAccount.exception.DuplicateEmailException;
 import com.souf.soufwebsite.domain.socialAccount.exception.NotValidAuthenticationException;
 import com.souf.soufwebsite.domain.socialAccount.repository.SocialAccountRepository;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
@@ -103,10 +104,7 @@ public class SocialAccountService {
 
         // 1-2) 소셜 연결은 없고, 이메일이 있고, 그 이메일로 기존 회원이 있으면 → 연결 필요
         if (info.email() != null && memberRepository.findByEmail(info.email()).isPresent()) {
-            return SocialLoginResDto.requiresLink(
-                    /* message */ "이미 가입된 이메일입니다. 기존 계정으로 로그인 후 '마이페이지 > 소셜 연결'에서 연동해 주세요.",
-                    /* prefill */ new SocialPrefill(info.email(), info.name(), info.profileImageUrl(), request.provider().name())
-            );
+            throw new DuplicateEmailException();
         }
 
         // 2) 연결이 없으면 → 온보딩 필요 (DB 생성 금지!)


### PR DESCRIPTION
## 개요
소셜 로그인 시도 시 해당 이메일의 유저가 있을 시 dto를 반환하는 기존의 구조에서 에러 처리로 수정

## 진행한 이슈
- close #197 

## 구현 내용
- <img width="791" height="116" alt="image" src="https://github.com/user-attachments/assets/5d075a88-58ce-48ab-8933-865685534522" />

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
