### PR TITLE
[FEAT] 기존 회원에 소셜로그인 연결 api 구현

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/controller/SocialAccountController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/controller/SocialAccountController.java
@@ -2,10 +2,12 @@ package com.souf.soufwebsite.domain.socialAccount.controller;
 
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import com.souf.soufwebsite.domain.socialAccount.dto.SocialCompleteSignupReqDto;
+import com.souf.soufwebsite.domain.socialAccount.dto.SocialLinkReqDto;
 import com.souf.soufwebsite.domain.socialAccount.dto.SocialLoginReqDto;
 import com.souf.soufwebsite.domain.socialAccount.dto.SocialLoginResDto;
 import com.souf.soufwebsite.domain.socialAccount.service.SocialAccountService;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.SecurityUtils;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 
 @RestController
@@ -31,5 +35,17 @@ public class SocialAccountController implements SocialAccountApiSpecification{
     public SuccessResponse<TokenDto> completeSignup(@RequestBody @Valid SocialCompleteSignupReqDto req,
                                                     HttpServletResponse res) {
         return new SuccessResponse<>(socialAccountService.completeSignup(req, res));
+    }
+
+    @PostMapping("/link")
+    public SuccessResponse<Map<String, Object>> link(
+            @RequestBody @Valid SocialLinkReqDto req
+    ) {
+        Long userId = SecurityUtils.getCurrentMember().getId();
+        socialAccountService.linkForLoggedIn(userId, req);
+        return new SuccessResponse<>(Map.of(
+                "linked", true,
+                "provider", req.provider().name()
+        ));
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/dto/SocialLinkReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/dto/SocialLinkReqDto.java
@@ -1,0 +1,10 @@
+package com.souf.soufwebsite.domain.socialAccount.dto;
+
+import com.souf.soufwebsite.domain.socialAccount.SocialProvider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SocialLinkReqDto(
+        @NotNull SocialProvider provider,
+        @NotBlank String code
+) {}

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/AlreadyLinkedException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/AlreadyLinkedException.java
@@ -1,0 +1,7 @@
+package com.souf.soufwebsite.domain.socialAccount.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+public class AlreadyLinkedException extends BaseErrorException {
+    public AlreadyLinkedException(){super(ErrorType.ALREADY_LINKED.getCode(), ErrorType.ALREADY_LINKED.getMessage());}
+}

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/AlreadyLinkedOtherUserException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/AlreadyLinkedOtherUserException.java
@@ -1,0 +1,7 @@
+package com.souf.soufwebsite.domain.socialAccount.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+public class AlreadyLinkedOtherUserException extends BaseErrorException {
+    public AlreadyLinkedOtherUserException(){super(ErrorType.ALREADY_LINKED_OTHER_USER.getCode(), ErrorType.ALREADY_LINKED_OTHER_USER.getMessage());}
+}

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/ErrorType.java
@@ -8,7 +8,9 @@ import lombok.Getter;
 public enum ErrorType {
 
     NOT_VALID_AUTHENTICATION(403, "해당 소셜 계정으로 로그인할 수 없습니다"),
-    DUPLICATE_EMAIL(409, "이미 가입된 이메일입니다. 마이페이지에서 소셜 계정을 연결해주세요.");
+    DUPLICATE_EMAIL(409, "이미 가입된 이메일입니다. 마이페이지에서 소셜 계정을 연결해주세요."),
+    ALREADY_LINKED_OTHER_USER(409, "이미 다른 사용자에 연결된 소셜 계정입니다."),
+    ALREADY_LINKED(409, "이미 해당 소셜 제공자가 연결되어 있습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/repository/SocialAccountRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/repository/SocialAccountRepository.java
@@ -4,10 +4,13 @@ import com.souf.soufwebsite.domain.socialAccount.SocialProvider;
 import com.souf.soufwebsite.domain.socialAccount.entity.SocialAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 // SocialAccountRepository.java
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
 
     Optional<SocialAccount> findByProviderAndProviderUserId(SocialProvider provider, String providerUserId);
+
+    List<SocialAccount> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/service/SocialAccountService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/service/SocialAccountService.java
@@ -14,6 +14,8 @@ import com.souf.soufwebsite.domain.socialAccount.SocialProvider;
 import com.souf.soufwebsite.domain.socialAccount.client.SocialApiClient;
 import com.souf.soufwebsite.domain.socialAccount.dto.*;
 import com.souf.soufwebsite.domain.socialAccount.entity.SocialAccount;
+import com.souf.soufwebsite.domain.socialAccount.exception.AlreadyLinkedException;
+import com.souf.soufwebsite.domain.socialAccount.exception.AlreadyLinkedOtherUserException;
 import com.souf.soufwebsite.domain.socialAccount.exception.DuplicateEmailException;
 import com.souf.soufwebsite.domain.socialAccount.exception.NotValidAuthenticationException;
 import com.souf.soufwebsite.domain.socialAccount.repository.SocialAccountRepository;
@@ -202,6 +204,50 @@ public class SocialAccountService {
         slackService.sendSlackMessage(member.getNickname() + " 님이 회원가입했습니다.", "signup");
 
         return token;
+    }
+
+    @Transactional
+    public void linkForLoggedIn(Long memberId, SocialLinkReqDto req) {
+        // 1) 현재 로그인 사용자 조회
+        Member me = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalStateException("Member not found"));
+
+        // 2) provider로 토큰 교환 + 사용자 정보 조회
+        SocialApiClient client = clientMap.get(req.provider());
+        if (client == null) throw new IllegalArgumentException("Unsupported provider: " + req.provider());
+
+        SocialUserInfo info = client.getUserInfoByCode(req.code());
+
+        // 3) 이미 다른 멤버에 연결된 소셜인지 방어
+        socialAccountRepository.findByProviderAndProviderUserId(req.provider(), info.socialId())
+                .ifPresent(existing -> {
+                    if (!existing.getMember().getId().equals(memberId)) {
+                        // 다른 계정에 묶인 소셜
+                        throw new AlreadyLinkedOtherUserException();
+                    } else {
+                        // 내 계정에 이미 같은 소셜이 연결돼 있음
+                        throw new AlreadyLinkedException();
+                    }
+                });
+
+        // 4) 내 계정에 같은 provider가 이미 있는지(다른 socialId로) 점검
+        boolean hasSameProvider = socialAccountRepository.findAllByMemberId(memberId).stream()
+                .anyMatch(sa -> sa.getProvider() == req.provider());
+        if (hasSameProvider) {
+            throw new AlreadyLinkedException();
+        }
+
+        // 5) 연결 엔티티 생성
+        SocialAccount link = SocialAccount.builder()
+                .provider(req.provider())
+                .providerUserId(info.socialId())
+                .member(me)
+                .providerEmail(info.email())
+                .displayName(info.name())
+                .profileImageUrl(info.profileImageUrl())
+                .build();
+
+        socialAccountRepository.save(link);
     }
 
     private TokenDto issueTokens(Member member) {


### PR DESCRIPTION
## 개요
기존 회원이 로그인 한 후 마이페이지에서 소셜로그인을 연결할 수 있도록 구현

## 진행한 이슈
- close #197 

## 구현 내용
- redirectUri 를 통해 카카오/구글에서 provider, token을 받아온 뒤, 해당 정보를 가지고 socialAccount 생성 후 연결합니다.
- <img width="916" height="556" alt="image" src="https://github.com/user-attachments/assets/6f898e39-5dd7-440c-8bbb-8ea680610f03" />
- 해당 소셜 계정이 다른 계정에 이미 연결되어 있는지 or 해당 계정이 이미 소셜 계정과 연결되어 있는지 확인 후 저장
- <img width="809" height="480" alt="image" src="https://github.com/user-attachments/assets/3555895d-1074-4f4e-815d-ca178ad0a350" />


## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
