### PR TITLE
Refactor: 패키지별 api 기능 점검

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/application/controller/ApplicationSuccessMessage.java
+++ b/src/main/java/com/souf/soufwebsite/domain/application/controller/ApplicationSuccessMessage.java
@@ -1,0 +1,22 @@
+package com.souf.soufwebsite.domain.application.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ApplicationSuccessMessage {
+
+    /* ============================== STUDENT ======================== */
+    APPLY_SUCCESS("지원이 완료되었습니다."),
+    APPLY_CANCELED("지원이 취소되었습니다."),
+    MY_APPLICATION_READ_SUCCESS("내 지원서를 조회하였습니다."),
+
+    /* ============================== RECRUIT ======================== */
+    APPLY_ACCEPT("지원을 수락하였습니다."),
+    APPLY_REJECT("지원을 거절하였습니다."),
+    APPLICATION_READ_SUCCESS("지원서를 조회하였습니다.");
+
+
+    private final String message;
+}

--- a/src/main/java/com/souf/soufwebsite/domain/application/controller/RecruitApplicationApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/application/controller/RecruitApplicationApiSpecification.java
@@ -2,6 +2,7 @@ package com.souf.soufwebsite.domain.application.controller;
 
 import com.souf.soufwebsite.domain.application.dto.ApplicantResDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
@@ -16,15 +17,20 @@ public interface RecruitApplicationApiSpecification {
     @Operation(summary = "특정 공고문 지원자 리스트 조회", description = "특정 공고문에 지원한 지원자들의 리스트를 조회합니다.")
     @GetMapping("/{recruitId}/applicants")
     SuccessResponse<Page<ApplicantResDto>> getApplicantsForRecruit(
+            @CurrentEmail String email,
             @PathVariable Long recruitId,
-            @PageableDefault(size = 10) Pageable pageable
+            @PageableDefault Pageable pageable
     );
 
     @Operation(summary = "지원 승인", description = "특정 지원자의 지원을 승인합니다.")
     @PostMapping("/{applicationId}/approve")
-    SuccessResponse<?> reviewApplication(@PathVariable Long applicationId);
+    SuccessResponse<?> reviewApplication(
+            @CurrentEmail String email,
+            @PathVariable Long applicationId);
 
     @Operation(summary = "지원 거절", description = "특정 지원자의 지원을 거절합니다.")
     @PostMapping("/{applicationId}/reject")
-    SuccessResponse<?> rejectApplication(@PathVariable Long applicationId);
+    SuccessResponse<?> rejectApplication(
+            @CurrentEmail String email,
+            @PathVariable Long applicationId);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/application/controller/RecruitApplicationController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/application/controller/RecruitApplicationController.java
@@ -3,11 +3,14 @@ package com.souf.soufwebsite.domain.application.controller;
 import com.souf.soufwebsite.domain.application.dto.ApplicantResDto;
 import com.souf.soufwebsite.domain.application.service.ApplicationService;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
+
+import static com.souf.soufwebsite.domain.application.controller.ApplicationSuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,21 +21,28 @@ public class RecruitApplicationController implements RecruitApplicationApiSpecif
 
     @GetMapping("/{recruitId}/applicants")
     public SuccessResponse<Page<ApplicantResDto>> getApplicantsForRecruit(
+            @CurrentEmail String email,
             @PathVariable Long recruitId,
-            @PageableDefault(size = 10) Pageable pageable
+            @PageableDefault Pageable pageable
     ) {
-        return new SuccessResponse<>(applicationService.getApplicantsByRecruit(recruitId, pageable));
+        return new SuccessResponse<>(
+                applicationService.getApplicantsByRecruit(email, recruitId, pageable),
+                APPLICATION_READ_SUCCESS.getMessage());
     }
 
     @PostMapping("/{applicationId}/approve")
-    public SuccessResponse<?> reviewApplication(@PathVariable Long applicationId) {
-        applicationService.reviewApplication(applicationId, true);
-        return new SuccessResponse<>("지원이 수락되었습니다.");
+    public SuccessResponse<?> reviewApplication(
+            @CurrentEmail String email,
+            @PathVariable Long applicationId) {
+        applicationService.reviewApplication(email, applicationId, true);
+        return new SuccessResponse<>(APPLY_ACCEPT.getMessage());
     }
 
     @PostMapping("/{applicationId}/reject")
-    public SuccessResponse<?> rejectApplication(@PathVariable Long applicationId) {
-        applicationService.reviewApplication(applicationId, false);
-        return new SuccessResponse<>("지원이 거절되었습니다.");
+    public SuccessResponse<?> rejectApplication(
+            @CurrentEmail String email,
+            @PathVariable Long applicationId) {
+        applicationService.reviewApplication(email, applicationId, false);
+        return new SuccessResponse<>(APPLY_REJECT.getMessage());
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/application/controller/StudentApplicationApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/application/controller/StudentApplicationApiSpecification.java
@@ -2,6 +2,7 @@ package com.souf.soufwebsite.domain.application.controller;
 
 import com.souf.soufwebsite.domain.application.dto.MyApplicationResDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
@@ -17,13 +18,19 @@ public interface StudentApplicationApiSpecification {
 
     @Operation(summary = "지원하기", description = "특정 공고문에 지원합니다.")
     @PostMapping("/{recruitId}/apply")
-    SuccessResponse<?> apply(@PathVariable Long recruitId);
+    SuccessResponse<?> apply(
+            @CurrentEmail String email,
+            @PathVariable Long recruitId);
 
     @Operation(summary = "지원 취소", description = "특정 공고문에 대한 지원을 취소합니다.")
     @DeleteMapping("/{recruitId}/apply")
-    SuccessResponse<?> deleteApplication(@PathVariable Long recruitId);
+    SuccessResponse<?> deleteApplication(
+            @CurrentEmail String email,
+            @PathVariable Long recruitId);
 
     @Operation(summary = "내 지원 리스트 조회", description = "사용자 본인이 지원한 공고문 리스트를 조회합니다.")
     @GetMapping("/my")
-    SuccessResponse<Page<MyApplicationResDto>> getMyApplications(@PageableDefault(size = 10) Pageable pageable);
+    SuccessResponse<Page<MyApplicationResDto>> getMyApplications(
+            @CurrentEmail String email,
+            @PageableDefault Pageable pageable);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/application/controller/StudentApplicationController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/application/controller/StudentApplicationController.java
@@ -4,11 +4,14 @@ package com.souf.soufwebsite.domain.application.controller;
 import com.souf.soufwebsite.domain.application.dto.MyApplicationResDto;
 import com.souf.soufwebsite.domain.application.service.ApplicationService;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
+
+import static com.souf.soufwebsite.domain.application.controller.ApplicationSuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,21 +21,28 @@ public class StudentApplicationController implements StudentApplicationApiSpecif
     private final ApplicationService applicationService;
 
     @PostMapping("/{recruitId}/apply")
-    public SuccessResponse<?> apply(@PathVariable Long recruitId) {
-        applicationService.apply(recruitId);
-        return new SuccessResponse<>("지원이 완료되었습니다.");
+    public SuccessResponse<?> apply(
+            @CurrentEmail String email,
+            @PathVariable Long recruitId) {
+        applicationService.apply(email, recruitId);
+        return new SuccessResponse<>(APPLY_SUCCESS.getMessage());
     }
 
     @DeleteMapping("/{recruitId}/apply")
-    public SuccessResponse<?> deleteApplication(@PathVariable Long recruitId) {
-        applicationService.deleteApplication(recruitId);
-        return new SuccessResponse<>("지원이 취소되었습니다.");
+    public SuccessResponse<?> deleteApplication(
+            @CurrentEmail String email,
+            @PathVariable Long recruitId) {
+        applicationService.deleteApplication(email, recruitId);
+        return new SuccessResponse<>(APPLY_CANCELED.getMessage());
     }
 
     @GetMapping("/my")
     public SuccessResponse<Page<MyApplicationResDto>> getMyApplications(
-            @PageableDefault(size = 10) Pageable pageable
+            @CurrentEmail String email,
+            @PageableDefault Pageable pageable
     ) {
-        return new SuccessResponse<>(applicationService.getMyApplications(pageable));
+        return new SuccessResponse<>(
+                applicationService.getMyApplications(email, pageable),
+                MY_APPLICATION_READ_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/application/service/ApplicationService.java
@@ -6,9 +6,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ApplicationService {
-    void apply(Long recruitId);
-    void deleteApplication(Long recruitId);
-    Page<MyApplicationResDto> getMyApplications(Pageable pageable);
-    Page<ApplicantResDto> getApplicantsByRecruit(Long recruitId, Pageable pageable);
-    void reviewApplication(Long applicationId, boolean approve);
+    void apply(String email, Long recruitId);
+    void deleteApplication(String email, Long recruitId);
+    Page<MyApplicationResDto> getMyApplications(String email, Pageable pageable);
+    Page<ApplicantResDto> getApplicantsByRecruit(String email, Long recruitId, Pageable pageable);
+    void reviewApplication(String email, Long applicationId, boolean approve);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/comment/controller/CommentApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/comment/controller/CommentApiSpecification.java
@@ -4,6 +4,7 @@ import com.souf.soufwebsite.domain.comment.dto.CommentReqDto;
 import com.souf.soufwebsite.domain.comment.dto.CommentResDto;
 import com.souf.soufwebsite.domain.comment.dto.CommentUpdateReqDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
@@ -45,12 +46,14 @@ public interface CommentApiSpecification {
     @Operation(summary = "댓글 수정", description = "사용자가 작성한 댓글을 수정합니다.")
     @PatchMapping
     SuccessResponse updateComment(
+            @CurrentEmail String email,
             @PathVariable Long postId,
             @RequestBody CommentUpdateReqDto reqDto);
 
     @Operation(summary = "댓글 삭제", description = "사용자가 작성한 댓글을 삭제합니다.")
     @DeleteMapping("/{commentId}")
     SuccessResponse deleteComment(
+            @CurrentEmail String email,
             @PathVariable Long postId,
             @PathVariable(name = "commentId") Long commentId);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import com.souf.soufwebsite.domain.comment.dto.CommentResDto;
 import com.souf.soufwebsite.domain.comment.dto.CommentUpdateReqDto;
 import com.souf.soufwebsite.domain.comment.service.CommentService;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -64,19 +65,21 @@ public class CommentController implements CommentApiSpecification{
 
     @PatchMapping
     public SuccessResponse updateComment(
+            @CurrentEmail String email,
             @PathVariable(name = "postId") Long postId,
             @Valid @RequestBody CommentUpdateReqDto reqDto) {
-        commentService.updateComment(postId, reqDto);
+        commentService.updateComment(email, postId, reqDto);
 
         return new SuccessResponse(UPDATE_COMMENT_SUCCESS.getMessage());
     }
 
     @DeleteMapping("/{commentId}")
     public SuccessResponse deleteComment(
+            @CurrentEmail String email,
             @PathVariable(name = "postId") Long postId,
             @PathVariable(name = "commentId") Long commentId) {
 
-        commentService.deleteComment(postId, commentId);
+        commentService.deleteComment(email, postId, commentId);
 
         return new SuccessResponse(DELETE_COMMENT_SUCCESS.getMessage());
     }

--- a/src/main/java/com/souf/soufwebsite/domain/comment/service/CommentService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/comment/service/CommentService.java
@@ -13,9 +13,9 @@ public interface CommentService {
 
     void createReply(Long postId, CommentReqDto reqDto);
 
-    void deleteComment(Long postId, Long commentId);
+    void deleteComment(String email, Long postId, Long commentId);
 
-    void updateComment(Long postId, CommentUpdateReqDto reqDto);
+    void updateComment(String email, Long postId, CommentUpdateReqDto reqDto);
 
     Slice<CommentResDto> getComments(Long postId, Pageable pageable);
 

--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
@@ -3,6 +3,7 @@ package com.souf.soufwebsite.domain.feed.controller;
 import com.souf.soufwebsite.domain.feed.dto.*;
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,6 +20,7 @@ public interface FeedApiSpecification {
     @Operation(summary = "피드 생성", description = "학생 권한을 가진 사용자가 피드를 생성합니다.")
     @PostMapping
     SuccessResponse<FeedResDto> createFeed(
+            @CurrentEmail String email,
             @RequestBody @Valid FeedReqDto feedReqDto);
 
     @Operation(summary = "해당 피드 관련 미디어 파일 정보 저장", description = "제공된 presignedUrl을 통해 업로드한 파일의 정보를 DB에도 반영할 수 있도록 서버에게 파일 정보를 보냅니다.")
@@ -34,18 +36,22 @@ public interface FeedApiSpecification {
     @Operation(summary = "특정 피드 상세 조회", description = "특정 피드에 대한 상세 정보를 조회합니다.")
     @GetMapping("/{memberId}/{feedId}")
     SuccessResponse<FeedDetailResDto> getDetailedFeed(
+            @CurrentEmail String email,
             @PathVariable(name = "memberId") Long memberId,
             @PathVariable(name = "feedId") Long feedId);
 
     @Operation(summary = "특정 피드 수정", description = "사용자 본인이 소유한 피드에 대해 수정합니다.")
     @PatchMapping("/{feedId}")
     SuccessResponse<FeedResDto> updateFeed(
+            @CurrentEmail String email,
             @PathVariable(name = "feedId") Long feedId,
             @RequestBody @Valid FeedReqDto reqDto);
 
     @Operation(summary = "특정 피드 삭제", description = "사용자 본인이 소유한 피드를 삭제합니다.")
     @DeleteMapping("/{feedId}")
-    SuccessResponse<?> deleteFeed(@PathVariable(name = "feedId") Long feedId);
+    SuccessResponse<?> deleteFeed(
+            @CurrentEmail String email,
+            @PathVariable(name = "feedId") Long feedId);
 
     @Operation(summary = "인기있는 피드 조회", description = "인기있는 피드를 조회합니다.")
     @GetMapping("/popular")

--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
@@ -4,6 +4,7 @@ import com.souf.soufwebsite.domain.feed.dto.*;
 import com.souf.soufwebsite.domain.feed.service.FeedService;
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,8 +27,9 @@ public class FeedController implements FeedApiSpecification{
 
     @PostMapping
     public SuccessResponse<FeedResDto> createFeed(
+            @CurrentEmail String email,
             @RequestBody @Valid FeedReqDto feedReqDto) {
-        FeedResDto feedResDto = feedService.createFeed(feedReqDto);
+        FeedResDto feedResDto = feedService.createFeed(email, feedReqDto);
 
         return new SuccessResponse<>(feedResDto, FEED_CREATE.getMessage());
     }
@@ -48,22 +50,26 @@ public class FeedController implements FeedApiSpecification{
 
     @GetMapping("/{memberId}/{feedId}")
     public SuccessResponse<FeedDetailResDto> getDetailedFeed(
+            @CurrentEmail String email,
             @PathVariable(name = "memberId") Long memberId,
             @PathVariable(name = "feedId") Long feedId) {
-        return new SuccessResponse<>(feedService.getFeedById(memberId, feedId), FEED_GET.getMessage());
+        return new SuccessResponse<>(feedService.getFeedById(email, memberId, feedId), FEED_GET.getMessage());
     }
 
     @PatchMapping("/{feedId}")
     public SuccessResponse<FeedResDto> updateFeed(
+            @CurrentEmail String email,
             @PathVariable(name = "feedId") Long feedId,
             @RequestBody @Valid FeedReqDto reqDto) {
-        FeedResDto feedResDto = feedService.updateFeed(feedId, reqDto);
+        FeedResDto feedResDto = feedService.updateFeed(email, feedId, reqDto);
         return new SuccessResponse<>(feedResDto, FEED_UPDATE.getMessage());
     }
 
     @DeleteMapping("/{feedId}")
-    public SuccessResponse<?> deleteFeed(@PathVariable(name = "feedId") Long feedId) {
-        feedService.deleteFeed(feedId);
+    public SuccessResponse<?> deleteFeed(
+            @CurrentEmail String email,
+            @PathVariable(name = "feedId") Long feedId) {
+        feedService.deleteFeed(email, feedId);
         return new SuccessResponse<>(FEED_DELETE.getMessage());
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedReqDto.java
@@ -10,7 +10,7 @@ import java.util.List;
 public record FeedReqDto(
 
         @Schema(description = "제목", example = "봄 프로젝트 1회차")
-        @NotEmpty
+        @NotEmpty(message = "제목은 한 자 이상 반드시 기입해주셔야 합니다.")
         String topic,
 
         @Schema(description = "피드 내용", example = "오늘 작업 내용...")
@@ -21,10 +21,11 @@ public record FeedReqDto(
         List<String> existingImageUrls,
 
         @Schema(description = "원본 파일 이름", example = "[fileName.jpg, dog.jpg..]")
+        @NotNull(message = "없더라도 빈 값을 넣어주세요.")
         List<String> originalFileNames,
 
         @Schema(description = "카테고리 목록", implementation = CategoryDto.class)
-        @NotNull(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
+        @NotEmpty(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
         List<CategoryDto> categoryDtos
         ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedService.java
@@ -9,17 +9,17 @@ import java.util.List;
 
 public interface FeedService {
 
-    FeedResDto createFeed(FeedReqDto reqDto);
+    FeedResDto createFeed(String email, FeedReqDto reqDto);
 
     void uploadFeedMedia(MediaReqDto mediaReqDto);
 
     MemberFeedResDto getStudentFeeds(Long memberId, Pageable pageable);
 
-    FeedDetailResDto getFeedById(Long memberId, Long feedId);
+    FeedDetailResDto getFeedById(String email, Long memberId, Long feedId);
 
-    FeedResDto updateFeed(Long feedId, FeedReqDto reqDto);
+    FeedResDto updateFeed(String email, Long feedId, FeedReqDto reqDto);
 
-    void deleteFeed(Long feedId);
+    void deleteFeed(String email, Long feedId);
 
     List<FeedSimpleResDto> getPopularFeeds(Pageable pageable);
 

--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
@@ -30,7 +30,6 @@ import com.souf.soufwebsite.global.common.category.entity.ThirdCategory;
 import com.souf.soufwebsite.global.common.category.service.CategoryService;
 import com.souf.soufwebsite.global.redis.util.RedisUtil;
 import com.souf.soufwebsite.global.slack.service.SlackService;
-import com.souf.soufwebsite.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -59,14 +58,10 @@ public class FeedServiceImpl implements FeedService {
     private final LikedFeedRepository likedFeedRepository;
     private final CommentRepository commentRepository;
 
-    private Member getCurrentUser() {
-        return SecurityUtils.getCurrentMember();
-    }
-
     @Override
     @Transactional
-    public FeedResDto createFeed(FeedReqDto reqDto) {
-        Member member = getCurrentUser();
+    public FeedResDto createFeed(String email, FeedReqDto reqDto) {
+        Member member = findIfEmailExists(email);
 
         Feed feed = Feed.of(reqDto, member);
         injectCategories(reqDto, feed);
@@ -93,6 +88,7 @@ public class FeedServiceImpl implements FeedService {
         return new FeedResDto(feed.getId(), presignedUrlResDtos, videoDto);
     }
 
+
     @Override
     public void uploadFeedMedia(MediaReqDto mediaReqDto) {
         Feed feed = findIfFeedExist(mediaReqDto.postId());
@@ -102,7 +98,7 @@ public class FeedServiceImpl implements FeedService {
     @Transactional(readOnly = true)
     @Override
     public MemberFeedResDto getStudentFeeds(Long memberId, Pageable pageable) {
-        Member member = findIfMemberExists(memberId);
+        Member member = findIfMemberIdExists(memberId);
         String mediaUrl = fileService.getMediaUrl(PostType.PROFILE, member.getId());
         Page<FeedSimpleResDto> feedSimpleResDtos = feedRepository.findAllByMemberOrderByIdDesc(member, pageable)
                 .map(feedConverter::getFeedSimpleResDto);
@@ -113,9 +109,13 @@ public class FeedServiceImpl implements FeedService {
 
     @Transactional(readOnly = true)
     @Override
-    public FeedDetailResDto getFeedById(Long memberId, Long feedId) {
+    public FeedDetailResDto getFeedById(String email, Long memberId, Long feedId) {
 
-        Member member = findIfMemberExists(memberId);
+        // 현재 사용자
+        Member currentMember = memberRepository.findByEmail(email).orElse(null);
+
+        // 피드 소유자
+        Member member = findIfMemberIdExists(memberId);
         Feed feed = findIfFeedExist(feedId);
 
         String feedViewKey = getFeedViewKey(feed.getId());
@@ -123,7 +123,10 @@ public class FeedServiceImpl implements FeedService {
         Long viewCountFromRedis = redisUtil.get(feedViewKey);
 
         Long likedCount = likedFeedRepository.countByFeedId(feedId).orElse(0L);
-        Boolean liked = getLiked(member.getId(), feedId);
+        Boolean liked = false;
+        if(currentMember != null) {
+            liked = getLiked(currentMember.getId(), feedId);
+        }
 
         Long commentCount = commentRepository.countByFeed(feed).orElse(0L);
 
@@ -135,8 +138,8 @@ public class FeedServiceImpl implements FeedService {
 
     @Transactional
     @Override
-    public FeedResDto updateFeed(Long feedId, FeedReqDto reqDto) {
-        Member member = getCurrentUser();
+    public FeedResDto updateFeed(String email, Long feedId, FeedReqDto reqDto) {
+        Member member = findIfEmailExists(email);
         Feed feed = findIfFeedExist(feedId);
         verifyIfFeedIsMine(feed, member);
 
@@ -160,8 +163,8 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
-    public void deleteFeed(Long feedId) {
-        Member member = getCurrentUser();
+    public void deleteFeed(String email, Long feedId) {
+        Member member = findIfEmailExists(email);
         Feed feed = findIfFeedExist(feedId);
         verifyIfFeedIsMine(feed, member);
 
@@ -217,7 +220,7 @@ public class FeedServiceImpl implements FeedService {
     @Override
     public void updateLikedCount(Long feedId, LikeFeedReqDto likeFeedReqDto) {
         Feed feed = findIfFeedExist(feedId);
-        Member member = findIfMemberExists(likeFeedReqDto.memberId());
+        Member member = findIfMemberIdExists(likeFeedReqDto.memberId());
 
         // 좋아요를 누를 경우
         if(likeFeedReqDto.isLiked().equals(Boolean.TRUE)){
@@ -243,8 +246,12 @@ public class FeedServiceImpl implements FeedService {
         return feedRepository.findById(id).orElseThrow(NotFoundFeedException::new);
     }
 
-    private Member findIfMemberExists(Long memberId) {
+    private Member findIfMemberIdExists(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(NotFoundFeedException::new);
+    }
+
+    private Member findIfEmailExists(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(NotFoundFeedException::new);
     }
 
     private String getFeedViewKey(Long feedId) {

--- a/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaReqDto.java
@@ -2,7 +2,7 @@ package com.souf.soufwebsite.domain.file.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
@@ -12,11 +12,11 @@ public record MediaReqDto(
         Long postId,
 
         @Schema(description = "해당 파일에 접근할 수 있는 url", example = "https://iamsouf.s3.amazonaws.com/feed/original/example.jpg" )
-        @NotEmpty(message = "url은 필수입니다.")
+        @NotBlank(message = "url은 필수입니다.")
         List<String> fileUrl,
 
         @Schema(description = "해당 공고문/피드의 원래 파일 이름", example = "[fileName, pictureName, spring, hihi]")
-        @NotBlank(message = "파일 이름은 필수입니다.")
+        @NotNull(message = "파일 이름은 필수입니다.")
         List<String> fileName,
 
         @Schema(description = "해당 파일의 확장자", example = "[jpg, jpg, png, jpeg]")

--- a/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/dto/MediaReqDto.java
@@ -1,20 +1,26 @@
 package com.souf.soufwebsite.domain.file.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
 public record MediaReqDto(
         @Schema(description = "해당 공고문/피드의 아이디", example = "1")
+        @NotBlank(message = "아이디는 필수입니다.")
         Long postId,
 
         @Schema(description = "해당 파일에 접근할 수 있는 url", example = "https://iamsouf.s3.amazonaws.com/feed/original/example.jpg" )
+        @NotEmpty(message = "url은 필수입니다.")
         List<String> fileUrl,
 
         @Schema(description = "해당 공고문/피드의 원래 파일 이름", example = "[fileName, pictureName, spring, hihi]")
+        @NotBlank(message = "파일 이름은 필수입니다.")
         List<String> fileName,
 
-        @Schema(description = "해당 공고문/피드의 아이디", example = "[jpg, jpg, png, jpeg]")
+        @Schema(description = "해당 파일의 확장자", example = "[jpg, jpg, png, jpeg]")
+        @NotBlank(message = "파일 확장자는 필수입니다.")
         List<String> fileType
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
@@ -7,6 +7,7 @@ import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberUpdateResDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -31,7 +32,9 @@ public interface MemberApiSpecification {
 
     @Operation(summary = "내 정보 조회", description = "로그인된 사용자의 회원 정보를 조회합니다.")
     @GetMapping("/member/myinfo")
-    SuccessResponse<MemberResDto> getMyInfo();
+    SuccessResponse<MemberResDto> getMyInfo(
+            @CurrentEmail String email
+    );
 
     @Operation(summary = "회원 단건 조회", description = "회원 ID로 특정 회원의 상세 정보를 조회합니다.")
     @GetMapping("/member/{id}")
@@ -58,6 +61,7 @@ public interface MemberApiSpecification {
     @Operation(summary = "회원정보 수정", description = "로그인된 사용자의 회원정보를 업데이트합니다.")
     @PutMapping("/update")
     SuccessResponse<MemberUpdateResDto> updateUserInfo(
+            @CurrentEmail String email,
             @RequestBody @Valid UpdateReqDto reqDto
     );
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberUpdateResDto;
 import com.souf.soufwebsite.domain.member.service.general.MemberService;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,8 +40,10 @@ public class MemberController implements MemberApiSpecification{
     }
 
     @GetMapping("/myinfo")
-    public SuccessResponse<MemberResDto> getMyInfo() {
-        MemberResDto meDto = memberService.getMyInfo();
+    public SuccessResponse<MemberResDto> getMyInfo(
+            @CurrentEmail String email
+    ) {
+        MemberResDto meDto = memberService.getMyInfo(email);
         return new SuccessResponse<>(meDto);
     }
 
@@ -72,8 +75,10 @@ public class MemberController implements MemberApiSpecification{
 //    }
 
     @PutMapping("/update")
-    public SuccessResponse<MemberUpdateResDto> updateUserInfo(@RequestBody UpdateReqDto reqDto) {
-        MemberUpdateResDto resDto = memberService.updateUserInfo(reqDto);
+    public SuccessResponse<MemberUpdateResDto> updateUserInfo(
+            @CurrentEmail String email,
+            @RequestBody UpdateReqDto reqDto) {
+        MemberUpdateResDto resDto = memberService.updateUserInfo(email, reqDto);
         return new SuccessResponse<>(resDto, "회원정보 수정 성공");
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthApiSpecification.java
@@ -3,6 +3,7 @@ package com.souf.soufwebsite.domain.member.controller.auth;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.*;
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -58,5 +59,11 @@ public interface AuthApiSpecification {
     SuccessResponse<Boolean> isNicknameAvailable(
             @RequestParam @NotEmpty String nickname
     );
+
+    @Operation(summary = "회원 탈퇴", description = "더이상 서비스를 사용하지 않을 유저가 스프를 탈퇴합니다.")
+    @DeleteMapping("/withdraw")
+    SuccessResponse<?> withdraw(
+            @CurrentEmail String email,
+            @RequestBody @Valid WithdrawReqDto reqDto);
 
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/auth/AuthController.java
@@ -4,6 +4,7 @@ import com.souf.soufwebsite.domain.member.dto.ReqDto.*;
 import com.souf.soufwebsite.domain.member.dto.TokenDto;
 import com.souf.soufwebsite.domain.member.service.general.MemberService;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
@@ -72,8 +73,10 @@ public class AuthController implements AuthApiSpecification{
     }
 
     @DeleteMapping("/withdraw")
-    public SuccessResponse<?> withdraw(@RequestBody @Valid WithdrawReqDto reqDto) {
-        memberService.withdraw(reqDto);
+    public SuccessResponse<?> withdraw(
+            @CurrentEmail String email,
+            @RequestBody @Valid WithdrawReqDto reqDto) {
+        memberService.withdraw(email, reqDto);
         return new SuccessResponse<>("회원 탈퇴 성공");
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberService.java
@@ -25,13 +25,13 @@ public interface MemberService {
 
     boolean verifyEmail(VerifyEmailReqDto reqDto);
 
-    MemberUpdateResDto updateUserInfo(UpdateReqDto reqDto);
+    MemberUpdateResDto updateUserInfo(String email, UpdateReqDto reqDto);
 
     void uploadProfileImage(MediaReqDto reqDto);
 
     Page<MemberSimpleResDto> getMembers(Long first, Long second, Long third, MemberSearchReqDto searchReqDto, Pageable pageable);
 
-    MemberResDto getMyInfo();
+    MemberResDto getMyInfo(String email);
 
     MemberResDto getMemberById(Long id);
 
@@ -41,5 +41,5 @@ public interface MemberService {
 
     boolean isNicknameAvailable(String nickname);
 
-    void withdraw(WithdrawReqDto reqDto);
+    void withdraw(String email, WithdrawReqDto reqDto);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberServiceImpl.java
@@ -69,8 +69,13 @@ public class MemberServiceImpl implements MemberService {
     private final CategoryService categoryService;
 
     //회원가입
+    @Transactional
     @Override
     public void signup(SignupReqDto reqDto) {
+
+        if (redisTemplate.hasKey("email:withdraw:" + reqDto.email())) {
+            throw new NotAllowedSignupException();
+        }
 
         String verifiedKey = "email:verified:" + reqDto.email();
         String isVerified = redisTemplate.opsForValue().get(verifiedKey);
@@ -116,9 +121,6 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public TokenDto signin(SigninReqDto reqDto, HttpServletResponse response) {
         log.info("email: {}, password: {}", reqDto.email(), reqDto.password());
-        if (redisTemplate.hasKey("email:withdraw:" + reqDto.email())) {
-            throw new NotAllowedSignupException();
-        }
 
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(reqDto.email(), reqDto.password());
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberServiceImpl.java
@@ -260,7 +260,7 @@ public class MemberServiceImpl implements MemberService {
     //회원정보 수정
     @Override
     @Transactional
-    public MemberUpdateResDto updateUserInfo(UpdateReqDto reqDto) {
+    public MemberUpdateResDto updateUserInfo(String email, UpdateReqDto reqDto) {
         Long memberId = getCurrentUser().getId();
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
@@ -319,7 +319,7 @@ public class MemberServiceImpl implements MemberService {
     //내 정보 조회
     @Override
     @Transactional(readOnly = true)
-    public MemberResDto getMyInfo() {
+    public MemberResDto getMyInfo(String email) {
         Member member = getCurrentUser();
         Member myMember = memberRepository.findById(member.getId()).orElseThrow(NotFoundMemberException::new); // 지연 로딩 오류 해결
         String mediaUrl = fileService.getMediaUrl(PostType.PROFILE, member.getId());
@@ -355,7 +355,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public void withdraw(WithdrawReqDto reqDto) {
+    public void withdraw(String email, WithdrawReqDto reqDto) {
         Long memberId = getCurrentUser().getId();
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
@@ -4,6 +4,7 @@ import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.MemberIdReqDto;
 import com.souf.soufwebsite.domain.recruit.dto.*;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,7 +20,9 @@ public interface RecruitApiSpecification {
 
     @Operation(summary = "공고문 생성", description = "일반 사용자의 권한을 가진 사용자가 공고문을 생성합니다.")
     @PostMapping
-    SuccessResponse<RecruitCreateResDto> createRecruit(@Valid @RequestBody RecruitReqDto recruitReqDto);
+    SuccessResponse<RecruitCreateResDto> createRecruit(
+            @CurrentEmail String email,
+            @Valid @RequestBody RecruitReqDto recruitReqDto);
 
     @Operation(summary = "해당 공고문 관련 미디어 파일 정보 저장", description = "제공된 presignedUrl을 통해 업로드한 파일의 정보를 DB에도 반영할 수 있도록 서버에게 파일 정보를 보냅니다.")
     @PostMapping("/upload")
@@ -39,20 +42,27 @@ public interface RecruitApiSpecification {
 
     @Operation(summary = "내 공고문 리스트 조회", description = "사용자 본인이 작성한 공고문 리스트를 조회합니다.")
     @GetMapping("/my")
-    SuccessResponse<Page<MyRecruitResDto>> getMyRecruits(@PageableDefault(size = 10) Pageable pageable);
+    SuccessResponse<Page<MyRecruitResDto>> getMyRecruits(
+            @CurrentEmail String email,
+            @PageableDefault Pageable pageable);
 
     @Operation(summary = "특정 공고문 수정", description = "사용자 본인이 소유한 공고문에 대해 수정합니다.")
     @PatchMapping("/{recruitId}")
-    SuccessResponse updateRecruit(@PathVariable(name = "recruitId") Long recruitId, @Valid @RequestBody RecruitReqDto recruitReqDto);
+    SuccessResponse updateRecruit(
+            @CurrentEmail String email,
+            @PathVariable(name = "recruitId") Long recruitId,
+            @Valid @RequestBody RecruitReqDto recruitReqDto);
 
     @Operation(summary = "특정 공고문 삭제", description = "사용자 본인이 소유한 공고문에 대해 삭제합니다.")
     @DeleteMapping("/{recruitId}")
-    SuccessResponse deleteRecruit(@PathVariable(name = "recruitId") Long recruitId);
+    SuccessResponse deleteRecruit(
+            @CurrentEmail String email,
+            @PathVariable(name = "recruitId") Long recruitId);
 
     @Operation(summary = "인기있는 공고문 조회", description = "사용자 조회 수 별로 인기있는 공고문을 조회합니다.")
     @GetMapping("/popular")
     SuccessResponse<List<RecruitPopularityResDto>> getPopularRecruits(
-            @PageableDefault(size = 10) Pageable pageable);
+            @PageableDefault Pageable pageable);
 
     @Operation(summary = "공고문 마감하기", description = "마감기한 전에 매칭된 공고문에 대해 소유자가 마감합니다.")
     @PatchMapping("/closure/{recruitId}")

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
@@ -6,6 +6,7 @@ import com.souf.soufwebsite.domain.recruit.dto.*;
 import com.souf.soufwebsite.domain.recruit.service.RecruitService;
 import com.souf.soufwebsite.global.redis.util.RedisUtil;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,8 +29,10 @@ public class RecruitController implements RecruitApiSpecification{
     private final RedisUtil redisUtil;
 
     @PostMapping
-    public SuccessResponse<RecruitCreateResDto> createRecruit(@Valid @RequestBody RecruitReqDto recruitReqDto) {
-        RecruitCreateResDto recruitCreateResDto = recruitService.createRecruit(recruitReqDto);
+    public SuccessResponse<RecruitCreateResDto> createRecruit(
+            @CurrentEmail String email,
+            @Valid @RequestBody RecruitReqDto recruitReqDto) {
+        RecruitCreateResDto recruitCreateResDto = recruitService.createRecruit(email, recruitReqDto);
 
         return new SuccessResponse<>(recruitCreateResDto, RECRUIT_CREATE.getMessage());
     }
@@ -61,27 +64,34 @@ public class RecruitController implements RecruitApiSpecification{
     }
 
     @GetMapping("/my")
-    public SuccessResponse<Page<MyRecruitResDto>> getMyRecruits(@PageableDefault(size = 10) Pageable pageable) {
+    public SuccessResponse<Page<MyRecruitResDto>> getMyRecruits(
+            @CurrentEmail String email,
+            @PageableDefault Pageable pageable) {
         // 페이징 10으로 설정, 추후 검토 후 수정 필요
-        return new SuccessResponse<>(recruitService.getMyRecruits(pageable), RECRUIT_GET.getMessage());
+        return new SuccessResponse<>(recruitService.getMyRecruits(email, pageable), RECRUIT_GET.getMessage());
     }
 
     @PatchMapping("/{recruitId}")
-    public SuccessResponse updateRecruit(@PathVariable(name = "recruitId") Long recruitId, @Valid @RequestBody RecruitReqDto recruitReqDto) {
-        RecruitCreateResDto recruitUpdateDto = recruitService.updateRecruit(recruitId, recruitReqDto);
+    public SuccessResponse updateRecruit(
+            @CurrentEmail String email,
+            @PathVariable(name = "recruitId") Long recruitId,
+            @Valid @RequestBody RecruitReqDto recruitReqDto) {
+        RecruitCreateResDto recruitUpdateDto = recruitService.updateRecruit(email, recruitId, recruitReqDto);
 
         return new SuccessResponse<>(recruitUpdateDto, RECRUIT_UPDATE.getMessage());
     }
 
     @DeleteMapping("/{recruitId}")
-    public SuccessResponse deleteRecruit(@PathVariable(name = "recruitId") Long recruitId) {
-        recruitService.deleteRecruit(recruitId);
+    public SuccessResponse deleteRecruit(
+            @CurrentEmail String email,
+            @PathVariable(name = "recruitId") Long recruitId) {
+        recruitService.deleteRecruit(email, recruitId);
         return new SuccessResponse(RECRUIT_DELETE.getMessage());
     }
 
     @GetMapping("/popular")
     public SuccessResponse<List<RecruitPopularityResDto>> getPopularRecruits(
-            @PageableDefault(size = 10) Pageable pageable
+            @PageableDefault Pageable pageable
     ) {
 
         log.info("공고문 캐싱 조회");

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/RecruitReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/RecruitReqDto.java
@@ -5,7 +5,7 @@ import com.souf.soufwebsite.domain.recruit.entity.WorkType;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -14,7 +14,7 @@ import java.util.List;
 
 public record RecruitReqDto(
         @Schema(description = "공고문 제목", example = "[SW] ggott sw 개발자 모집")
-        @NotEmpty(message = "공고문 제목은 필수입니다.")
+        @NotBlank(message = "공고문 제목은 필수입니다.")
         @Size(min = 2)
         String title,
 
@@ -24,7 +24,7 @@ public record RecruitReqDto(
         String content,
 
         @Schema(description = "지역 ID", example = "1")
-        @NotNull(message = "지역은 필수입니다.")
+        @NotBlank(message = "지역은 필수입니다.")
         Long cityId,
 
         @Schema(description = "세부 지역 ID", example = "1")
@@ -32,23 +32,23 @@ public record RecruitReqDto(
 
         @Schema(description = "마감 기한", example = "2025-06-23T13:29")
         @Future
-        @NotNull(message = "마감 기한은 필수입니다.")
+        @NotBlank(message = "마감 기한은 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
         LocalDateTime deadline,
 
         @Schema(description = "최소 제시 금액", example = "100만원")
-        @NotEmpty(message = "최소 제시 금액은 필수입니다.")
+        @NotBlank(message = "최소 제시 금액은 필수입니다.")
         String minPayment,
 
         @Schema(description = "최대 제시 금액", example = "100만원")
-        @NotEmpty(message = "최대 제시 금액은 필수입니다.")
+        @NotBlank(message = "최대 제시 금액은 필수입니다.")
         String maxPayment,
 
         @Schema(description = "우대사항", example = "1. 전공자 우대\n2. 군필자 우대\n3. Powerpoint를 다루어 본 자")
         String preferentialTreatment,
 
         @Schema(description = "카테고리 목록", implementation = CategoryDto.class)
-        @NotNull(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
+        @NotBlank(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
         List<CategoryDto> categoryDtos,
 
         @Schema(description = "기존에 존재하는 파일 URL", example = "[\"https://s3.../img1.jpg\", \"https://s3.../img2.jpg\"]")
@@ -58,7 +58,7 @@ public record RecruitReqDto(
         List<String> originalFileNames,
 
         @Schema(description = "업무 형태를 넣어주세요.", example = "OFFLINE or ONLINE")
-        @NotNull(message = "업무 형태를 반드시 지정해주세요.")
+        @NotBlank(message = "업무 형태를 반드시 지정해주세요.")
         WorkType workType
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitService.java
@@ -10,20 +10,20 @@ import java.util.List;
 
 public interface RecruitService {
 
-    RecruitCreateResDto createRecruit(RecruitReqDto reqDto);
+    RecruitCreateResDto createRecruit(String email, RecruitReqDto reqDto);
 
     void uploadRecruitMedia(MediaReqDto reqDto);
 
     Page<RecruitSimpleResDto> getRecruits(Long first, Long second, Long third,
                                           RecruitSearchReqDto searchReqDto, Pageable pageable);
 
-    Page<MyRecruitResDto> getMyRecruits(Pageable pageable);
+    Page<MyRecruitResDto> getMyRecruits(String email, Pageable pageable);
 
     RecruitResDto getRecruitById(Long recruitId);
 
-    RecruitCreateResDto updateRecruit(Long recruitId, RecruitReqDto reqDto);
+    RecruitCreateResDto updateRecruit(String email, Long recruitId, RecruitReqDto reqDto);
 
-    void deleteRecruit(Long recruitId);
+    void deleteRecruit(String email, Long recruitId);
 
     List<RecruitPopularityResDto> getPopularRecruits(Pageable pageable);
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
@@ -29,7 +29,6 @@ import com.souf.soufwebsite.global.common.category.entity.ThirdCategory;
 import com.souf.soufwebsite.global.common.category.service.CategoryService;
 import com.souf.soufwebsite.global.redis.util.RedisUtil;
 import com.souf.soufwebsite.global.slack.service.SlackService;
-import com.souf.soufwebsite.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -56,14 +55,10 @@ public class RecruitServiceImpl implements RecruitService {
     private final IndexEventPublisherHelper indexEventPublisherHelper;
     private final SlackService slackService;
 
-    private Member getCurrentUser() {
-        return SecurityUtils.getCurrentMember();
-    }
-
     @Override
     @Transactional
-    public RecruitCreateResDto createRecruit(RecruitReqDto reqDto) {
-        Member member = getCurrentUser();
+    public RecruitCreateResDto createRecruit(String email, RecruitReqDto reqDto) {
+        Member member = findIfEmailExists(email);
 
         City city = cityRepository.findById(reqDto.cityId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 City ID입니다."));
@@ -96,7 +91,7 @@ public class RecruitServiceImpl implements RecruitService {
     @Transactional
     public void uploadRecruitMedia(MediaReqDto reqDto) {
         Recruit recruit = findIfRecruitExist(reqDto.postId());
-        List<Media> mediaList = fileService.uploadMetadata(reqDto, PostType.RECRUIT, recruit.getId());
+        fileService.uploadMetadata(reqDto, PostType.RECRUIT, recruit.getId());
     }
 
     @Transactional(readOnly = true)
@@ -127,8 +122,8 @@ public class RecruitServiceImpl implements RecruitService {
 
     @Transactional(readOnly = true)
     @Override
-    public Page<MyRecruitResDto> getMyRecruits(Pageable pageable) {
-        Member me = getCurrentUser();
+    public Page<MyRecruitResDto> getMyRecruits(String email, Pageable pageable) {
+        Member me = findIfEmailExists(email);
         return recruitRepository.findByMember(me, pageable)
                 .map(r -> {
                     String status = r.isRecruitable() ? "모집 중" : "마감";
@@ -154,8 +149,8 @@ public class RecruitServiceImpl implements RecruitService {
 
     @Transactional
     @Override
-    public RecruitCreateResDto updateRecruit(Long recruitId, RecruitReqDto reqDto) {
-        Member member = getCurrentUser();
+    public RecruitCreateResDto updateRecruit(String email, Long recruitId, RecruitReqDto reqDto) {
+        Member member = findIfEmailExists(email);
         Recruit recruit = findIfRecruitExist(recruitId);
         verifyIfRecruitIsMine(recruit, member);
 
@@ -181,8 +176,8 @@ public class RecruitServiceImpl implements RecruitService {
     }
 
     @Override
-    public void deleteRecruit(Long recruitId) {
-        Member member = getCurrentUser();
+    public void deleteRecruit(String email, Long recruitId) {
+        Member member = findIfEmailExists(email);
         Recruit recruit = findIfRecruitExist(recruitId);
         verifyIfRecruitIsMine(recruit, member);
 
@@ -222,6 +217,9 @@ public class RecruitServiceImpl implements RecruitService {
         recruit.updateRecruitable();
     }
 
+    private Member findIfEmailExists(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new);
+    }
 
     private void verifyIfRecruitIsMine(Recruit recruit, Member member) {
         if(!recruit.getMember().getId().equals(member.getId())){

--- a/src/main/java/com/souf/soufwebsite/domain/report/controller/ReportApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/report/controller/ReportApiSpecification.java
@@ -2,6 +2,7 @@ package com.souf.soufwebsite.domain.report.controller;
 
 import com.souf.soufwebsite.domain.report.dto.ReportReqDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -14,6 +15,7 @@ public interface ReportApiSpecification {
     @Operation(summary = "게시글 신고하기", description = "사용자가 부적절한 게시글을 보고 신고합니다.")
     @PostMapping
     SuccessResponse createReport(
+            @CurrentEmail String email,
             @RequestBody @Valid ReportReqDto reportReqDto
             );
 }

--- a/src/main/java/com/souf/soufwebsite/domain/report/controller/ReportController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/report/controller/ReportController.java
@@ -3,6 +3,7 @@ package com.souf.soufwebsite.domain.report.controller;
 import com.souf.soufwebsite.domain.report.dto.ReportReqDto;
 import com.souf.soufwebsite.domain.report.service.ReportService;
 import com.souf.soufwebsite.global.success.SuccessResponse;
+import com.souf.soufwebsite.global.util.CurrentEmail;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,9 +24,10 @@ public class ReportController implements ReportApiSpecification {
 
     @PostMapping
     public SuccessResponse createReport(
+            @CurrentEmail String email,
             @RequestBody @Valid ReportReqDto reportReqDto
     ) {
-        reportService.createReport(reportReqDto);
+        reportService.createReport(email, reportReqDto);
 
         return new SuccessResponse(REPORT_CREATE.getMessage());
     }

--- a/src/main/java/com/souf/soufwebsite/domain/report/service/ReportService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/report/service/ReportService.java
@@ -4,5 +4,5 @@ import com.souf.soufwebsite.domain.report.dto.ReportReqDto;
 
 public interface ReportService {
 
-    void createReport(ReportReqDto reqDto);
+    void createReport(String email, ReportReqDto reqDto);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/report/service/ReportServiceImpl.java
@@ -10,7 +10,6 @@ import com.souf.soufwebsite.domain.report.entity.ReportReasonMapping;
 import com.souf.soufwebsite.domain.report.exception.NotMatchedReportOwnerException;
 import com.souf.soufwebsite.domain.report.repository.ReasonRepository;
 import com.souf.soufwebsite.domain.report.repository.ReportRepository;
-import com.souf.soufwebsite.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,14 +26,10 @@ public class ReportServiceImpl implements ReportService {
     private final ReportRepository reportRepository;
     private final ReasonRepository reasonRepository;
 
-    private Member getCurrentMember() {
-        return SecurityUtils.getCurrentMember();
-    }
-
     @Transactional
     @Override
-    public void createReport(ReportReqDto reqDto) {
-        Member currentMember = getCurrentMember();
+    public void createReport(String email, ReportReqDto reqDto) {
+        Member currentMember = findIfEmailExists(email);
 
         Member reporter = findIfMemberExists(reqDto.reporterId());
         Member reportedMember = findIfMemberExists(reqDto.reportedMemberId());
@@ -58,5 +53,9 @@ public class ReportServiceImpl implements ReportService {
 
     private Member findIfMemberExists(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(NotFoundFeedException::new);
+    }
+
+    private Member findIfEmailExists(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(NotFoundFeedException::new);
     }
 }

--- a/src/main/java/com/souf/soufwebsite/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/souf/soufwebsite/global/security/UserDetailsImpl.java
@@ -1,6 +1,7 @@
 package com.souf.soufwebsite.global.security;
 
 import com.souf.soufwebsite.domain.member.entity.Member;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,6 +9,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
+@Getter
 public class UserDetailsImpl implements UserDetails {
 
     private final Member member;
@@ -30,7 +32,6 @@ public class UserDetailsImpl implements UserDetails {
     @Override
     public String getUsername() { return member.getEmail(); }
 
-    public Member getMember() {
-        return member;
-    }
+    public String getEmail() { return member.getEmail(); }
+
 }

--- a/src/main/java/com/souf/soufwebsite/global/util/CurrentEmail.java
+++ b/src/main/java/com/souf/soufwebsite/global/util/CurrentEmail.java
@@ -1,0 +1,14 @@
+package com.souf.soufwebsite.global.util;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "email")
+public @interface CurrentEmail {
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- #204

## 구현 내용
- [x] 이슈에 기입된 사항들을 모두 충족했나요?
 패키지별로 구현된 API들을 점검하였습니다.
또한 서비스로직에서 SecurityContextHolder에서 직접적으로 멤버 객체를 가져오던 흐름을 API 전에 가져오도록 하였습니다.
그 이유는 다음과 같습니다.
1. 책임 분리 원칙에 어긋남.
2. 테스트가 어려워짐.
3. 매 호출마다 Member 엔티티를 로딩하여 불필요한 DB Hit가 발생

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
