### PR TITLE
[FEAT] 테스트 커버리지 도입

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/application/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/application/exception/ErrorType.java
@@ -9,8 +9,8 @@ public enum ErrorType {
 
     NOT_RECRUITABLE(400, "해당 공고는 지원이 종료되었습니다.", "A400-1"),
     ALREADY_APPLIED(409, "이미 지원한 공고입니다.", "A409-1"),
-    NOT_FOUND_APPLICATION(404, "해당 지원서를 찾을 수 없습니다.", "A404-2"),
-    NOT_VALID_AUTHENTICATION(403, "해당 지원을 관리할 권한이 없습니다", "A403-1"),
+    NOT_FOUND_APPLICATION(404, "해당 지원서를 찾을 수 없습니다.", "A404-1"),
+    NOT_VALID_AUTHENTICATION(403, "해당 지원을 관리할 권한이 없습니다.", "A403-1"),
     NOT_APPLY_MY_RECRUIT(400, "자신의 공고에는 지원할 수 없습니다.", "A400-2");
 
     private final int code;

--- a/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/controller/ChatRoomController.java
@@ -6,16 +6,17 @@ import com.souf.soufwebsite.domain.chat.dto.ChatRoomResDto;
 import com.souf.soufwebsite.domain.chat.dto.ChatRoomSummaryDto;
 import com.souf.soufwebsite.domain.chat.entity.ChatMessage;
 import com.souf.soufwebsite.domain.chat.entity.ChatRoom;
+import com.souf.soufwebsite.domain.chat.exception.NotChatRoomParticipantException;
 import com.souf.soufwebsite.domain.chat.service.ChatMessageService;
 import com.souf.soufwebsite.domain.chat.service.ChatRoomService;
 import com.souf.soufwebsite.domain.member.entity.Member;
+import com.souf.soufwebsite.domain.member.exception.NotFoundMemberException;
 import com.souf.soufwebsite.domain.member.repository.MemberRepository;
 import com.souf.soufwebsite.global.security.UserDetailsImpl;
 import com.souf.soufwebsite.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,7 +44,7 @@ public class ChatRoomController implements ChatRoomApiSpecificaton {
 
         Member sender = userDetails.getMember();
         Member receiver = memberRepository.findById(request.receiverId())
-                .orElseThrow(() -> new IllegalArgumentException("상대방을 찾을 수 없습니다"));
+                .orElseThrow(NotFoundMemberException::new);
 
         ChatRoom room = chatRoomService.findOrCreateRoom(sender, receiver);
 
@@ -67,7 +68,7 @@ public class ChatRoomController implements ChatRoomApiSpecificaton {
         ChatRoom room = chatRoomService.getRoomById(roomId);
 
         if (!room.hasParticipant(me)) {
-            throw new AccessDeniedException("채팅방에 참여한 유저만 조회할 수 있습니다.");
+            throw new NotChatRoomParticipantException();
         }
 
         List<ChatMessage> messages = chatMessageService.getMessages(roomId);

--- a/src/main/java/com/souf/soufwebsite/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/entity/ChatRoom.java
@@ -36,11 +36,4 @@ public class ChatRoom extends BaseEntity {
         return Objects.equals(this.getSender().getId(), member.getId()) ||
                 Objects.equals(this.getReceiver().getId(), member.getId());
     }
-
-
-    public Member getOpponent(Member me) {
-        if (me.equals(sender)) return receiver;
-        if (me.equals(receiver)) return sender;
-        throw new IllegalArgumentException("이 채팅방에 속하지 않은 유저입니다.");
-    }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/ErrorType.java
@@ -6,10 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorType {
-    NOT_FOUND_CHAT_MESSAGE(404, "해당 채팅을 찾을 수 없습니다!", "C404-1"),
-    NOT_CHAT_MYSELF(400, "자신과의 채팅은 생성할 수 없습니다!", "C400-1"),
+    NOT_FOUND_CHAT_MESSAGE(404, "해당 채팅을 찾을 수 없습니다.", "C404-1"),
+    NOT_CHAT_MYSELF(400, "자신과의 채팅은 생성할 수 없습니다.", "C400-1"),
     NOT_FOUND_CHAT_ROOM(404, "해당 채팅방을 찾을 수 없습니다.", "C404-2"),
-    NOT_FOUND_PARTICIPANT(404, "해당 채팅방의 참여자를 찾을 수 없습니다.", "C404-3");
+    NOT_FOUND_PARTICIPANT(404, "해당 채팅방의 참여자를 찾을 수 없습니다.", "C404-3"),
+    NOT_CHAT_ROOM_PARTICIPANT(403, "채팅방 참여자가 아닙니다.", "C403-1"),;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/ErrorType.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorType {
-    NOT_FOUND_CHAT_MESSAGE(404, "해당 채팅을 찾을 수 없습니다.", "C404-1"),
-    NOT_CHAT_MYSELF(400, "자신과의 채팅은 생성할 수 없습니다.", "C400-1"),
-    NOT_FOUND_CHAT_ROOM(404, "해당 채팅방을 찾을 수 없습니다.", "C404-2"),
-    NOT_FOUND_PARTICIPANT(404, "해당 채팅방의 참여자를 찾을 수 없습니다.", "C404-3"),
-    NOT_CHAT_ROOM_PARTICIPANT(403, "채팅방 참여자가 아닙니다.", "C403-1"),;
+    NOT_FOUND_CHAT_MESSAGE(404, "해당 채팅을 찾을 수 없습니다.", "CH404-1"),
+    NOT_CHAT_MYSELF(400, "자신과의 채팅은 생성할 수 없습니다.", "CH400-1"),
+    NOT_FOUND_CHAT_ROOM(404, "해당 채팅방을 찾을 수 없습니다.", "CH404-2"),
+    NOT_FOUND_PARTICIPANT(404, "해당 채팅방의 참여자를 찾을 수 없습니다.", "CH404-3"),
+    NOT_CHAT_ROOM_PARTICIPANT(403, "채팅방 참여자가 아닙니다.", "CH403-1"),;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/ErrorType.java
@@ -6,7 +6,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorType {
-    NOT_FOUND_CHAT_MESSAGE(404, "해당 채팅을 수정할 찾을 수 없습니다!", "C404-1");
+    NOT_FOUND_CHAT_MESSAGE(404, "해당 채팅을 찾을 수 없습니다!", "C404-1"),
+    NOT_CHAT_MYSELF(400, "자신과의 채팅은 생성할 수 없습니다!", "C400-1"),
+    NOT_FOUND_CHAT_ROOM(404, "해당 채팅방을 찾을 수 없습니다.", "C404-2"),
+    NOT_FOUND_PARTICIPANT(404, "해당 채팅방의 참여자를 찾을 수 없습니다.", "C404-3");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotChatMyselfException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotChatMyselfException.java
@@ -1,0 +1,9 @@
+package com.souf.soufwebsite.domain.chat.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+public class NotChatMyselfException extends BaseErrorException {
+    public NotChatMyselfException() {
+        super(ErrorType.NOT_CHAT_MYSELF.getCode(), ErrorType.NOT_CHAT_MYSELF.getMessage(), ErrorType.NOT_CHAT_MYSELF.getErrorKey());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotChatMyselfException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotChatMyselfException.java
@@ -2,8 +2,10 @@ package com.souf.soufwebsite.domain.chat.exception;
 
 import com.souf.soufwebsite.global.exception.BaseErrorException;
 
+import static com.souf.soufwebsite.domain.chat.exception.ErrorType.NOT_CHAT_MYSELF;
+
 public class NotChatMyselfException extends BaseErrorException {
     public NotChatMyselfException() {
-        super(ErrorType.NOT_CHAT_MYSELF.getCode(), ErrorType.NOT_CHAT_MYSELF.getMessage(), ErrorType.NOT_CHAT_MYSELF.getErrorKey());
+        super(NOT_CHAT_MYSELF.getCode(), NOT_CHAT_MYSELF.getMessage(), NOT_CHAT_MYSELF.getErrorKey());
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotChatRoomParticipantException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotChatRoomParticipantException.java
@@ -1,0 +1,11 @@
+package com.souf.soufwebsite.domain.chat.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.chat.exception.ErrorType.NOT_CHAT_ROOM_PARTICIPANT;
+
+public class NotChatRoomParticipantException extends BaseErrorException {
+    public NotChatRoomParticipantException() {
+        super(NOT_CHAT_ROOM_PARTICIPANT.getCode(), NOT_CHAT_ROOM_PARTICIPANT.getMessage(), NOT_CHAT_ROOM_PARTICIPANT.getErrorKey());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotFoundChatRoomException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotFoundChatRoomException.java
@@ -1,0 +1,9 @@
+package com.souf.soufwebsite.domain.chat.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+public class NotFoundChatRoomException extends BaseErrorException {
+    public NotFoundChatRoomException() {
+        super(ErrorType.NOT_FOUND_CHAT_ROOM.getCode(), ErrorType.NOT_FOUND_CHAT_ROOM.getMessage(), ErrorType.NOT_FOUND_CHAT_ROOM.getErrorKey());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotFoundChatRoomException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotFoundChatRoomException.java
@@ -2,8 +2,10 @@ package com.souf.soufwebsite.domain.chat.exception;
 
 import com.souf.soufwebsite.global.exception.BaseErrorException;
 
+import static com.souf.soufwebsite.domain.chat.exception.ErrorType.NOT_FOUND_CHAT_ROOM;
+
 public class NotFoundChatRoomException extends BaseErrorException {
     public NotFoundChatRoomException() {
-        super(ErrorType.NOT_FOUND_CHAT_ROOM.getCode(), ErrorType.NOT_FOUND_CHAT_ROOM.getMessage(), ErrorType.NOT_FOUND_CHAT_ROOM.getErrorKey());
+        super(NOT_FOUND_CHAT_ROOM.getCode(), NOT_FOUND_CHAT_ROOM.getMessage(), NOT_FOUND_CHAT_ROOM.getErrorKey());
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotFoundParticipantException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotFoundParticipantException.java
@@ -2,8 +2,10 @@ package com.souf.soufwebsite.domain.chat.exception;
 
 import com.souf.soufwebsite.global.exception.BaseErrorException;
 
+import static com.souf.soufwebsite.domain.chat.exception.ErrorType.NOT_FOUND_PARTICIPANT;
+
 public class NotFoundParticipantException extends BaseErrorException {
     public NotFoundParticipantException() {
-        super(ErrorType.NOT_FOUND_PARTICIPANT.getCode(), ErrorType.NOT_FOUND_PARTICIPANT.getMessage(), ErrorType.NOT_FOUND_PARTICIPANT.getErrorKey());
+        super(NOT_FOUND_PARTICIPANT.getCode(), NOT_FOUND_PARTICIPANT.getMessage(), NOT_FOUND_PARTICIPANT.getErrorKey());
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotFoundParticipantException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/exception/NotFoundParticipantException.java
@@ -1,0 +1,9 @@
+package com.souf.soufwebsite.domain.chat.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+public class NotFoundParticipantException extends BaseErrorException {
+    public NotFoundParticipantException() {
+        super(ErrorType.NOT_FOUND_PARTICIPANT.getCode(), ErrorType.NOT_FOUND_PARTICIPANT.getMessage(), ErrorType.NOT_FOUND_PARTICIPANT.getErrorKey());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/chat/service/ChatRoomService.java
@@ -4,6 +4,9 @@ import com.souf.soufwebsite.domain.chat.dto.ChatRoomSummaryDto;
 import com.souf.soufwebsite.domain.chat.entity.ChatMessage;
 import com.souf.soufwebsite.domain.chat.entity.ChatParticipant;
 import com.souf.soufwebsite.domain.chat.entity.ChatRoom;
+import com.souf.soufwebsite.domain.chat.exception.NotChatMyselfException;
+import com.souf.soufwebsite.domain.chat.exception.NotFoundChatRoomException;
+import com.souf.soufwebsite.domain.chat.exception.NotFoundParticipantException;
 import com.souf.soufwebsite.domain.chat.repository.ChatMessageRepository;
 import com.souf.soufwebsite.domain.chat.repository.ChatParticipantRepository;
 import com.souf.soufwebsite.domain.chat.repository.ChatRoomNativeRepository;
@@ -27,7 +30,7 @@ public class ChatRoomService {
     @Transactional
     public ChatRoom findOrCreateRoom(Member sender, Member receiver) {
         if (sender.equals(receiver)) {
-            throw new IllegalArgumentException("자기 자신과는 채팅할 수 없습니다.");
+            throw new NotChatMyselfException();
         }
 
         Optional<ChatRoom> existingRoomOpt = chatRoomRepository.findBySenderAndReceiver(sender, receiver)
@@ -56,13 +59,13 @@ public class ChatRoomService {
 
     public ChatRoom getRoomById(Long roomId) {
         return chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 존재하지 않습니다."));
+                .orElseThrow(NotFoundChatRoomException::new);
     }
 
     @Transactional
     public void exitChatRoom(Member member, Long roomId) {
         chatParticipantRepository.findByChatRoomIdAndMemberId(roomId, member.getId())
-                .orElseThrow(() -> new IllegalArgumentException("참여자 없음"))
+                .orElseThrow(NotFoundParticipantException::new)
                 .exit(); // exited = true로 변경
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/city/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/city/exception/ErrorType.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorType {
 
-    NOT_FOUND_CITY(404, "유효하지 않은 도시입니다.", "C404-1"),
-    NOT_FOUND_CITY_DETAIL(404, "유효하지 않은 지역입니다.", "C404-2"),
-    REQUIRED_CITY_DETAIL(400, "상세지역은 필수입니다.", "C400-1"),;
+    NOT_FOUND_CITY(404, "유효하지 않은 도시입니다.", "CT404-1"),
+    NOT_FOUND_CITY_DETAIL(404, "유효하지 않은 지역입니다.", "CT404-2"),
+    REQUIRED_CITY_DETAIL(400, "상세지역은 필수입니다.", "CT400-1"),;
 
 
     private final int code;

--- a/src/main/java/com/souf/soufwebsite/domain/city/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/city/exception/ErrorType.java
@@ -1,0 +1,18 @@
+package com.souf.soufwebsite.domain.city.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorType {
+
+    NOT_FOUND_CITY(404, "유효하지 않은 도시입니다.", "C404-1"),
+    NOT_FOUND_CITY_DETAIL(404, "유효하지 않은 지역입니다.", "C404-2"),
+    REQUIRED_CITY_DETAIL(400, "상세지역은 필수입니다.", "C400-1"),;
+
+
+    private final int code;
+    private final String message;
+    private final String errorKey;
+}

--- a/src/main/java/com/souf/soufwebsite/domain/city/exception/NotFoundCityDetailException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/city/exception/NotFoundCityDetailException.java
@@ -1,0 +1,11 @@
+package com.souf.soufwebsite.domain.city.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.city.exception.ErrorType.NOT_FOUND_CITY_DETAIL;
+
+public class NotFoundCityDetailException extends BaseErrorException {
+    public NotFoundCityDetailException() {
+        super(NOT_FOUND_CITY_DETAIL.getCode(), NOT_FOUND_CITY_DETAIL.getMessage(), NOT_FOUND_CITY_DETAIL.getErrorKey());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/city/exception/NotFoundCityException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/city/exception/NotFoundCityException.java
@@ -1,0 +1,11 @@
+package com.souf.soufwebsite.domain.city.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.city.exception.ErrorType.NOT_FOUND_CITY;
+
+public class NotFoundCityException extends BaseErrorException {
+    public NotFoundCityException() {
+        super(NOT_FOUND_CITY.getCode(), NOT_FOUND_CITY.getMessage(), NOT_FOUND_CITY.getErrorKey());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/city/exception/RequiredCityDetailException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/city/exception/RequiredCityDetailException.java
@@ -1,0 +1,11 @@
+package com.souf.soufwebsite.domain.city.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.city.exception.ErrorType.REQUIRED_CITY_DETAIL;
+
+public class RequiredCityDetailException extends BaseErrorException {
+    public RequiredCityDetailException() {
+        super(REQUIRED_CITY_DETAIL.getCode(), REQUIRED_CITY_DETAIL.getMessage(), REQUIRED_CITY_DETAIL.getErrorKey());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/comment/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/comment/exception/ErrorType.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorType {
 
-    NOT_FOUND_COMMENT(404, "해당 댓글을 찾을 수 없습니다.", "C404-1"),
-    NOT_MATCHED_OWNER(404, "해당 댓글의 소유자가 아닙니다.", "C404-2");
+    NOT_FOUND_COMMENT(404, "해당 댓글을 찾을 수 없습니다.", "CM404-1"),
+    NOT_MATCHED_OWNER(404, "해당 댓글의 소유자가 아닙니다.", "CM404-2");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/feed/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/exception/ErrorType.java
@@ -8,11 +8,11 @@ import lombok.Getter;
 public enum ErrorType {
 
     // FEED
-    NOT_VALID_AUTHENTICATION(403, "해당 피드를 수정할 권한이 없습니다!", "F403-1"),
+    NOT_VALID_AUTHENTICATION(403, "해당 피드를 수정할 권한이 없습니다.", "F403-1"),
     NOT_FOUND_FEED(404, "해당 피드를 찾을 수 없습니다.", "F404-1"),
 
     // LIKE_FEED
-    ALREADY_EXISTS_LIKE(400, "이미 좋아요를 누르셨습니다.", "F400-1"),
+    ALREADY_EXISTS_LIKE(400, "이미 좋아요를 눌렀습니다.", "F400-1"),
     NOT_EXISTS_LIKE(404, "좋아요를 누르지 않았습니다.", "F404-2"),
     NOT_FOUND_FEED_LIKE(400, "해당 회원의 좋아요 여부를 확인할 수 없습니다.", "F400-2");
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/exception/ErrorType.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorType {
 
-    NOT_VALID_AUTHENTICATION(401, "해당 공고를 수정할 권한이 없습니다!", "R401-1"),
+    NOT_VALID_AUTHENTICATION(401, "해당 공고를 수정할 권한이 없습니다.", "R401-1"),
     NOT_FOUND_RECRUIT(404, "해당 공고를 찾을 수 없습니다.", "R404-1"),
     NOT_VALID_DEADLINE(400, "유효하지 않은 날짜입니다.", "R400-1");
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
@@ -2,6 +2,9 @@ package com.souf.soufwebsite.domain.recruit.service;
 
 import com.souf.soufwebsite.domain.city.entity.City;
 import com.souf.soufwebsite.domain.city.entity.CityDetail;
+import com.souf.soufwebsite.domain.city.exception.NotFoundCityDetailException;
+import com.souf.soufwebsite.domain.city.exception.NotFoundCityException;
+import com.souf.soufwebsite.domain.city.exception.RequiredCityDetailException;
 import com.souf.soufwebsite.domain.city.repository.CityDetailRepository;
 import com.souf.soufwebsite.domain.city.repository.CityRepository;
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
@@ -63,7 +66,7 @@ public class RecruitServiceImpl implements RecruitService {
         Member member = findIfEmailExists(email);
 
         City city = cityRepository.findById(reqDto.cityId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 City ID입니다."));
+                .orElseThrow(NotFoundCityException::new);
         CityDetail cityDetail = validateCityOrThrow(city, reqDto.cityDetailId());
 
         Recruit recruit = Recruit.of(reqDto, member, city, cityDetail);
@@ -137,7 +140,7 @@ public class RecruitServiceImpl implements RecruitService {
         verifyIfRecruitIsMine(recruit, member);
 
         City city = cityRepository.findById(reqDto.cityId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 City ID입니다."));
+                .orElseThrow(NotFoundCityException::new);
         CityDetail cityDetail = validateCityOrThrow(city, reqDto.cityDetailId());
 
         updateRemainingImages(reqDto, recruit);
@@ -239,10 +242,10 @@ public class RecruitServiceImpl implements RecruitService {
             return null;
         }
         if (cityDetailId == null) {
-            throw new IllegalArgumentException("세부 지역은 필수입니다.");
+            throw new RequiredCityDetailException();
         }
         return cityDetailRepository.findById(cityDetailId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 cityDetail ID입니다."));
+                .orElseThrow(NotFoundCityDetailException::new);
     }
 
     private void updateRemainingImages(RecruitReqDto reqDto, Recruit recruit) {

--- a/src/main/java/com/souf/soufwebsite/domain/report/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/report/exception/ErrorType.java
@@ -7,17 +7,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorType {
 
-    NOT_MATCHED_REPORT_OWNER(400, "신고자와 현재 사용자가 일치하지 않습니다.", "R400-1"),
-    NOT_FOUND_REPORT(404, "해당 신고 내역이 존재하지 않습니다.", "R404-1"),
+    NOT_MATCHED_REPORT_OWNER(400, "신고자와 현재 사용자가 일치하지 않습니다.", "RP400-1"),
+    NOT_FOUND_REPORT(404, "해당 신고 내역이 존재하지 않습니다.", "RP404-1"),
 
     /* ============================== 신고 사유 ===================================== */
 
-    NOT_FOUND_REPORT_REASON(404, "해당 신고 사유가 존재하지 않습니다.", "R404-2"),
+    NOT_FOUND_REPORT_REASON(404, "해당 신고 사유가 존재하지 않습니다.", "RP404-2"),
 
     /* ============================= 재제 예외 -------------------------------------- */
 
-    DUPLICATE_SANCTION(400, "동일한 내역이 이미 존재합니다.", "R400-2"),
-    DECLARED_MEMBER(401, "이미 신고된 회원입니다.", "R401-1");
+    DUPLICATE_SANCTION(400, "동일한 내역이 이미 존재합니다.", "RP400-2"),
+    DECLARED_MEMBER(401, "이미 신고된 회원입니다.", "RP401-1");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/ErrorType.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/ErrorType.java
@@ -10,7 +10,9 @@ public enum ErrorType {
     NOT_VALID_AUTHENTICATION(400, "해당 소셜 계정으로 로그인할 수 없습니다", "S400-1"),
     DUPLICATE_EMAIL(400, "이미 가입된 이메일입니다. 마이페이지에서 소셜 계정을 연결해주세요.", "S400-2"),
     ALREADY_LINKED_OTHER_USER(400, "이미 다른 사용자에 연결된 소셜 계정입니다.", "S400-3"),
-    ALREADY_LINKED(400, "이미 해당 소셜 제공자가 연결되어 있습니다.", "S400-4"),;
+    ALREADY_LINKED(400, "이미 해당 소셜 제공자가 연결되어 있습니다.", "S400-4"),
+    NOT_VALID_PROVIDER(400, "유효하지 않은 소셜 제공자입니다.", "S400-5"),
+    NOT_VALID_TOKEN(400, "유효하지 않은 토큰입니다.", "S400-6"),;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/NotValidProviderException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/NotValidProviderException.java
@@ -1,0 +1,11 @@
+package com.souf.soufwebsite.domain.socialAccount.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.socialAccount.exception.ErrorType.NOT_VALID_PROVIDER;
+
+public class NotValidProviderException extends BaseErrorException {
+    public NotValidProviderException() {
+        super(NOT_VALID_PROVIDER.getCode(), NOT_VALID_PROVIDER.getMessage(), NOT_VALID_PROVIDER.getErrorKey());
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/NotValidTokenException.java
+++ b/src/main/java/com/souf/soufwebsite/domain/socialAccount/exception/NotValidTokenException.java
@@ -1,0 +1,11 @@
+package com.souf.soufwebsite.domain.socialAccount.exception;
+
+import com.souf.soufwebsite.global.exception.BaseErrorException;
+
+import static com.souf.soufwebsite.domain.socialAccount.exception.ErrorType.NOT_VALID_TOKEN;
+
+public class NotValidTokenException extends BaseErrorException {
+    public NotValidTokenException() {
+        super(NOT_VALID_TOKEN.getCode(), NOT_VALID_TOKEN.getMessage(), NOT_VALID_TOKEN.getErrorKey());
+    }
+}


### PR DESCRIPTION
## 개요
소셜로그인, 채팅, 도시/지역 관련 에러 메시지 작성
C, R 과 같이 중복되는 errorKey 수정

## 진행한 이슈
- close #211

## 구현 내용
- [x] 채팅 기능 관련 에러 메시지 작성 및 errorKey CH 로 설정
- [x] 소셜로그인 관련 에러 메시지 작성 및 errorKey S 로 설정
- [x] 도시/지역 (city / cityDetail) 관련 에러 메시지 작성 및 errorKey CT 로 설정

- [x] 카테고리, 채팅, 도시, 댓글 의 errorKey 가 C로 중복되어 차례대로 C, CH, CT, CM 으로 수정
- [x] 공고 (recruit), 신고 의 errorKey 가 R로 중복되어 차례대로 R, RP 로 수정

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
