### PR TITLE
Fix/#216/인기 게시글 조회 기능 수정

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
@@ -54,8 +54,7 @@ public interface FeedApiSpecification {
 
     @Operation(summary = "인기있는 피드 조회", description = "인기있는 피드를 조회합니다.")
     @GetMapping("/popular")
-    SuccessResponse<List<FeedSimpleResDto>> getPopularFeeds(
-            @PageableDefault(size = 6) Pageable pageable);
+    SuccessResponse<List<FeedSimpleResDto>> getPopularFeeds();
 
     @Operation(summary = "대학생 피드 조회", description = "피드들을 조회합니다.")
     @GetMapping

--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
@@ -36,7 +36,6 @@ public interface FeedApiSpecification {
     @Operation(summary = "특정 피드 상세 조회", description = "특정 피드에 대한 상세 정보를 조회합니다.")
     @GetMapping("/{memberId}/{feedId}")
     SuccessResponse<FeedDetailResDto> getDetailedFeed(
-            @CurrentEmail String email,
             @PathVariable(name = "memberId") Long memberId,
             @PathVariable(name = "feedId") Long feedId);
 

--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
@@ -50,10 +50,10 @@ public class FeedController implements FeedApiSpecification{
 
     @GetMapping("/{memberId}/{feedId}")
     public SuccessResponse<FeedDetailResDto> getDetailedFeed(
-            @CurrentEmail String email,
             @PathVariable(name = "memberId") Long memberId,
             @PathVariable(name = "feedId") Long feedId) {
-        return new SuccessResponse<>(feedService.getFeedById(email, memberId, feedId), FEED_GET.getMessage());
+
+        return new SuccessResponse<>(feedService.getFeedById(memberId, feedId), FEED_GET.getMessage());
     }
 
     @PatchMapping("/{feedId}")

--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
@@ -74,11 +74,10 @@ public class FeedController implements FeedApiSpecification{
     }
 
     @GetMapping("/popular")
-    public SuccessResponse<List<FeedSimpleResDto>> getPopularFeeds(
-            @PageableDefault(size = 6) Pageable pageable){
+    public SuccessResponse<List<FeedSimpleResDto>> getPopularFeeds(){
 
         log.info("피드 캐싱 조회");
-        return new SuccessResponse<>(feedService.getPopularFeeds(pageable),
+        return new SuccessResponse<>(feedService.getPopularFeeds(),
                 FEED_GET_POPULATION.getMessage());
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/feed/entity/Feed.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/entity/Feed.java
@@ -37,6 +37,10 @@ public class Feed extends BaseEntity {
     @Column(nullable = false)
     private Long viewCount;
 
+    @NotNull
+    @Column(nullable = false)
+    private Long weeklyViews;
+
     @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
@@ -53,6 +57,7 @@ public class Feed extends BaseEntity {
         this.content = content;
         this.member = member;
         this.viewCount = 0L;
+        this.weeklyViews = 0L;
     }
 
     public static Feed of(FeedReqDto createReqDto, Member member) {

--- a/src/main/java/com/souf/soufwebsite/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/repository/FeedRepository.java
@@ -19,9 +19,15 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRep
     @Transactional
     @Modifying
     @Query("update Feed f set f.viewCount = f.viewCount + :count where f.id = :feedId")
-    void increaseViewCount(@Param("feedId") Long feedId, @Param("count") Long count);
+    void increaseTotalViewCount(@Param("feedId") Long feedId, @Param("count") Long count);
 
-    Page<Feed> findByOrderByViewCountDesc(Pageable pageable);
+    @Transactional
+    @Modifying
+    @Query("update Feed f set f.weeklyViews = f.weeklyViews + :count where f.id = :feedId")
+    void increaseWeeklyViewCount(@Param("feedId") Long feedId, @Param("count") Long count);
+
+    @Query("select f from Feed f join fetch f.member m order by f.weeklyViews desc limit 6")
+    List<Feed> findTop6ByOrderByWeeklyViewCountDesc();
 
     List<Feed> findTop3ByMemberOrderByViewCountDesc(Member member);
 

--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedScheduledService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedScheduledService.java
@@ -3,18 +3,17 @@ package com.souf.soufwebsite.domain.feed.service;
 import com.souf.soufwebsite.domain.feed.dto.FeedSimpleResDto;
 import com.souf.soufwebsite.domain.feed.entity.Feed;
 import com.souf.soufwebsite.domain.feed.repository.FeedRepository;
-import com.souf.soufwebsite.global.redis.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Slf4j
@@ -23,28 +22,66 @@ import java.util.Set;
 public class FeedScheduledService {
 
     private final FeedRepository feedRepository;
-    private final RedisUtil redisUtil;
     private final CacheManager cacheManager;
     private final FeedConverter feedConverter;
+    private final StringRedisTemplate redisTemplate;
+
+    public static final String WEEKLY_ZSET = "feed:views:weekly:";
+    public static final String TOTAL_HASH = "feed:views:total:";
 
     @Transactional
-    public void syncViewCountsToDB() {
-        Set<String> keys = redisUtil.getKeys("feed:view:*");
+    public void syncWeeklyViewCountsToDB() {
+        Set<ZSetOperations.TypedTuple<String>> tuples = redisTemplate.opsForZSet().rangeWithScores(WEEKLY_ZSET, 0, -1);
 
-        if (keys == null || keys.isEmpty()) return;
-
-        for (String key : keys) {
-            Long feedId = Long.parseLong(key.replace("feed:view:", ""));
-            Long viewCountInRedis = redisUtil.get(key);
-            if (viewCountInRedis == null || viewCountInRedis == 0L) continue;
-
-            // DB의 기존 viewCount에 더해줌
-            feedRepository.increaseViewCount(feedId, viewCountInRedis);
-
-            // Redis 값 0으로 초기화
-            redisUtil.set(key);
+        if(tuples == null || tuples.isEmpty()) {
+            return;
         }
-        log.info("피드 조회수 스케줄링 작업 완료");
+
+        for (ZSetOperations.TypedTuple<String> tuple : tuples) {
+            String value = tuple.getValue();
+            Double score = tuple.getScore();
+
+            if(value == null || score == null) {
+                continue;
+            }
+
+            Long feedId = Long.valueOf(value);
+            long weeklyViewCount = score.longValue();
+
+            feedRepository.findById(feedId).ifPresent(feed -> {
+                feedRepository.increaseWeeklyViewCount(feedId, weeklyViewCount);
+            });
+        }
+
+        redisTemplate.delete(WEEKLY_ZSET); // 주간 초기화
+
+        log.info("피드 주간 조회수 DB에 반영 완료");
+    }
+
+    @Transactional
+    public void syncTotalViewCountsToDB() {
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(TOTAL_HASH);
+
+        if(entries.isEmpty()) {
+            return;
+        }
+
+        for(Object key : entries.keySet()) {
+            Object value = entries.get(key);
+            if(value == null) {
+                continue;
+            }
+
+            Long feedId = Long.valueOf((String) key);
+            Long totalViewCount = Long.valueOf((String) value);
+            feedRepository.findById(feedId).ifPresent(feed -> {
+                feedRepository.increaseTotalViewCount(feedId, totalViewCount);
+            });
+        }
+
+        redisTemplate.delete(TOTAL_HASH);
+
+        log.info("누적 조회수 DB에 반영 완료");
     }
 
     @Transactional
@@ -55,22 +92,16 @@ public class FeedScheduledService {
             return;
         }
 
-        for (int i = 0; i < 3; i++) {
-            Pageable pageable = PageRequest.of(i, 6);
-            // repo가 null을 주지 않는 게 보통이지만 혹시 모르니 방어코드
-            Page<Feed> feeds = feedRepository.findByOrderByViewCountDesc(pageable);
-            if (feeds == null) feeds = Page.empty(pageable);
+        List<Feed> popularFeeds = feedRepository.findTop6ByOrderByWeeklyViewCountDesc();
+        List<FeedSimpleResDto> result = popularFeeds.stream()
+                .map(feedConverter::getFeedSimpleResDto)
+                .toList();
+        cache.put("feed:popular", result);
 
-            List<FeedSimpleResDto> dto = feeds.getContent().stream()
-                    .map(feedConverter::getFeedSimpleResDto)
-                    .toList();
-
-            cache.put(buildKey(pageable), dto);
-        }
         log.info("인기 피드 캐싱 완료");
     }
 
-    private String buildKey(Pageable pageable) {
-        return "page:" + pageable.getPageNumber() + ":" + pageable.getPageSize();
-    }
+//    private String buildKey(Pageable pageable) {
+//        return "page:" + pageable.getPageNumber() + ":" + pageable.getPageSize();
+//    }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedService.java
@@ -21,7 +21,7 @@ public interface FeedService {
 
     void deleteFeed(String email, Long feedId);
 
-    List<FeedSimpleResDto> getPopularFeeds(Pageable pageable);
+    List<FeedSimpleResDto> getPopularFeeds();
 
     Slice<FeedDetailResDto> getFeeds(Long first, Pageable pageable);
 

--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedService.java
@@ -15,7 +15,7 @@ public interface FeedService {
 
     MemberFeedResDto getStudentFeeds(Long memberId, Pageable pageable);
 
-    FeedDetailResDto getFeedById(String email, Long memberId, Long feedId);
+    FeedDetailResDto getFeedById(Long memberId, Long feedId);
 
     FeedResDto updateFeed(String email, Long feedId, FeedReqDto reqDto);
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
@@ -65,8 +65,7 @@ public interface RecruitApiSpecification {
 
     @Operation(summary = "인기있는 공고문 조회", description = "사용자 조회 수 별로 인기있는 공고문을 조회합니다.")
     @GetMapping("/popular")
-    SuccessResponse<List<RecruitPopularityResDto>> getPopularRecruits(
-            @PageableDefault Pageable pageable);
+    SuccessResponse<List<RecruitPopularityResDto>> getPopularRecruits();
 
     @Operation(summary = "공고문 마감하기", description = "마감기한 전에 매칭된 공고문에 대해 소유자가 마감합니다.")
     @PatchMapping("/closure/{recruitId}")

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
@@ -95,14 +95,13 @@ public class RecruitController implements RecruitApiSpecification{
 
     @GetMapping("/popular")
     public SuccessResponse<List<RecruitPopularityResDto>> getPopularRecruits(
-            @PageableDefault Pageable pageable
     ) {
 
         log.info("공고문 캐싱 조회");
         redisUtil.increaseCount("view:main:totalCount");
 
         return new SuccessResponse<>(
-                recruitService.getPopularRecruits(pageable),
+                recruitService.getPopularRecruits(),
                 RECRUIT_GET_POPULATION.getMessage());
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/RecruitReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/RecruitReqDto.java
@@ -38,11 +38,7 @@ public record RecruitReqDto(
 
         @Schema(description = "최소 제시 금액", example = "100만원")
         @NotBlank(message = "최소 제시 금액은 필수입니다.")
-        String minPayment,
-
-        @Schema(description = "최대 제시 금액", example = "100만원")
-        @NotBlank(message = "최대 제시 금액은 필수입니다.")
-        String maxPayment,
+        String price,
 
         @Schema(description = "우대사항", example = "1. 전공자 우대\n2. 군필자 우대\n3. Powerpoint를 다루어 본 자")
         String preferentialTreatment,

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitPopularityResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitPopularityResDto.java
@@ -32,6 +32,6 @@ public record RecruitPopularityResDto(
 
     private static long leftDays(LocalDateTime deadline) {
         LocalDateTime now = LocalDateTime.now();
-        return ChronoUnit.DAYS.between(now, deadline);
+        return ChronoUnit.DAYS.between(deadline, now);
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitPopularityResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitPopularityResDto.java
@@ -3,6 +3,7 @@ package com.souf.soufwebsite.domain.recruit.dto.res;
 import com.souf.soufwebsite.domain.recruit.entity.Recruit;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 public record RecruitPopularityResDto(
         Long recruitId,
@@ -10,9 +11,8 @@ public record RecruitPopularityResDto(
         String content,
         Long firstCategory,
         Long secondCategory,
-        LocalDateTime deadLine,
-        String minPayment,
-        String maxPayment,
+        Long deadLine,
+        String price,
         String nickname,
         String profile
 ) {
@@ -23,11 +23,15 @@ public record RecruitPopularityResDto(
                 recruit.getContent(),
                 recruit.getCategories().get(0).getFirstCategory().getId(),
                 recruit.getCategories().get(0).getSecondCategory().getId(),
-                recruit.getDeadline(),
-                recruit.getMinPayment(),
-                recruit.getMaxPayment(),
+                leftDays(recruit.getDeadline()),
+                recruit.getPrice(),
                 recruit.getMember().getNickname(),
                 profile
         );
+    }
+
+    private static long leftDays(LocalDateTime deadline) {
+        LocalDateTime now = LocalDateTime.now();
+        return ChronoUnit.DAYS.between(now, deadline);
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitResDto.java
@@ -20,15 +20,15 @@ public record RecruitResDto(
         String cityName,
         String cityDetailName,
         String deadline,
-        String minPayment,
-        String maxPayment,
+        String price,
+        Long totalViewCount,
         String preferentialTreatment,
         String nickname,
         boolean recruitable,
         List<CategoryDto> categoryDtoList,
         List<MediaResDto> mediaResDtos
 ) {
-    public static RecruitResDto from(Long memberId, Recruit recruit, String nickname, List<Media> mediaList) {
+    public static RecruitResDto from(Long memberId, Recruit recruit, Long totalViewCount, String nickname, List<Media> mediaList) {
         return new RecruitResDto(
                 memberId,
                 recruit.getId(),
@@ -37,8 +37,8 @@ public record RecruitResDto(
                 recruit.getCity().getName(),
                 recruit.getCityDetail() != null ? recruit.getCityDetail().getName() : null,
                 convertToDateTime(recruit.getDeadline()),
-                recruit.getMinPayment(),
-                recruit.getMaxPayment(),
+                recruit.getPrice(),
+                totalViewCount,
                 recruit.getPreferentialTreatment(),
                 nickname,
                 recruit.isRecruitable(),

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitSimpleResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitSimpleResDto.java
@@ -11,8 +11,7 @@ public record RecruitSimpleResDto(
         String title,
         List<Long> secondCategory,
         String content,
-        String minPayment,
-        String maxPayment,
+        String price,
         String cityName,
         String cityDetailName,
         String deadLine,
@@ -21,12 +20,12 @@ public record RecruitSimpleResDto(
         LocalDateTime lastModified
 ) {
     public static RecruitSimpleResDto of(Long recruitId, String title, Long secondCategoryId, String content,
-                                         String minPayment, String maxPayment, String cityName, String cityDetailName,
+                                         String price, String cityName, String cityDetailName,
                                          LocalDateTime deadLine, Long recruitCount, boolean recruitable, LocalDateTime lastModified) {
         return new RecruitSimpleResDto(
                 recruitId, title,
                 new ArrayList<>(List.of(secondCategoryId)), // 초기 리스트
-                content, minPayment, maxPayment, cityName, cityDetailName,
+                content, price, cityName, cityDetailName,
                 convertToDateTime(deadLine), recruitCount, recruitable, lastModified
         );
     }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/entity/Recruit.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/entity/Recruit.java
@@ -38,19 +38,18 @@ public class Recruit extends BaseEntity {
     private City city;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "cityDetail_id", nullable = true)
+    @JoinColumn(name = "cityDetail_id")
     private CityDetail cityDetail;
 
+    @Column
+    private LocalDateTime startTime;
 
     // 마감일자
     @Column
     private LocalDateTime deadline;
 
     @Column(nullable = false)
-    private String minPayment;
-
-    @Column(nullable = false)
-    private String maxPayment;
+    private String price;
 
     @Column
     private String preferentialTreatment;
@@ -85,8 +84,7 @@ public class Recruit extends BaseEntity {
                 .city(city)
                 .cityDetail(cityDetail)
                 .deadline(reqDto.deadline())
-                .minPayment(reqDto.minPayment())
-                .maxPayment(reqDto.maxPayment())
+                .price(reqDto.price())
                 .preferentialTreatment(reqDto.preferentialTreatment())
                 .recruitCount(0L)
                 .viewCount(0L)
@@ -101,8 +99,7 @@ public class Recruit extends BaseEntity {
         this.city = city;
         this.cityDetail = cityDetail;
         this.deadline = reqDto.deadline();
-        this.minPayment = reqDto.minPayment();
-        this.maxPayment = reqDto.maxPayment();
+        this.price = reqDto.price();
         this.workType = reqDto.workType();
         this.preferentialTreatment = reqDto.preferentialTreatment();
     }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepositoryImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepositoryImpl.java
@@ -50,8 +50,7 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
                         recruit.title,
                         recruitCategoryMapping.secondCategory.id,
                         recruit.content,
-                        recruit.minPayment,
-                        recruit.maxPayment,
+                        recruit.price,
                         recruit.city.name,
                         recruit.cityDetail.name,
                         recruit.deadline,
@@ -90,8 +89,7 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
                         t.get(recruit.title),
                         secondCatId,
                         t.get(recruit.content),
-                        t.get(recruit.minPayment),
-                        t.get(recruit.maxPayment),
+                        t.get(recruit.price),
                         cityName,
                         cityDetailName,
                         t.get(recruit.deadline),
@@ -170,7 +168,7 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
     private NumberExpression<Integer> maxPaymentNumber() {
         return Expressions.numberTemplate(Integer.class,
                 "cast(nullif(replace(replace(trim({0}), '만원', ''), ',', ''), '') as integer)",
-                recruit.maxPayment
+                recruit.price
         );
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitRepository.java
@@ -1,6 +1,5 @@
 package com.souf.soufwebsite.domain.recruit.repository;
 
-import com.souf.soufwebsite.domain.member.entity.Member;
 import com.souf.soufwebsite.domain.recruit.entity.Recruit;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RecruitRepository extends JpaRepository<Recruit, Long>, RecruitCustomRepository {
@@ -17,23 +17,9 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long>, Recruit
     @Query("update Recruit r set r.viewCount = r.viewCount + :count where r.id = :recruitId")
     void increaseViewCount(@Param("recruitId") Long recruitId, @Param("count") Long count);
 
-    @Query(
-            value = """
-                SELECT DISTINCT r
-                FROM Recruit r
-                JOIN FETCH r.member m
-                WHERE r.recruitable = true
-                ORDER BY r.viewCount DESC, r.id DESC
-            """,
-            countQuery = """
-                SELECT COUNT(r)
-                FROM Recruit r
-                WHERE r.recruitable = true
-            """
-    )
-    Page<Recruit> findByRecruitableTrueOrderByViewCountDesc(Pageable pageable);
+    @Query("select r from Recruit r where r.recruitable=true and r.deadline > :now order by r.deadline limit 5")
+    List<Recruit> findTop5ByRecruitableAndDeadlineAfterOrderByDeadlineDesc(@Param("now") LocalDateTime now);
 
-    Page<Recruit> findByMember(Member member, Pageable pageable);
 
     List<Recruit> findByRecruitableTrue();
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitScheduledService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitScheduledService.java
@@ -5,19 +5,18 @@ import com.souf.soufwebsite.domain.file.service.FileService;
 import com.souf.soufwebsite.domain.recruit.dto.res.RecruitPopularityResDto;
 import com.souf.soufwebsite.domain.recruit.entity.Recruit;
 import com.souf.soufwebsite.domain.recruit.repository.RecruitRepository;
-import com.souf.soufwebsite.global.redis.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -25,27 +24,34 @@ import java.util.Set;
 public class RecruitScheduledService {
 
     private final RecruitRepository recruitRepository;
-    private final RedisUtil redisUtil;
+    private final StringRedisTemplate redisTemplate;
     private final CacheManager cacheManager;
     private final FileService fileService;
 
+    public static final String TOTAL_HASH = "recruit:views:total:";
+
     @Transactional
     public void syncViewCountsToDB() {
-        Set<String> keys = redisUtil.getKeys("recruit:view:*");
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(TOTAL_HASH);
 
-        if (keys == null || keys.isEmpty()) return;
-
-        for (String key : keys) {
-            Long recruitId = Long.parseLong(key.replace("recruit:view:", ""));
-            Long viewCountInRedis = redisUtil.get(key);
-            if (viewCountInRedis == null || viewCountInRedis == 0L) continue;
-
-            // DB의 기존 viewCount에 더해줌
-            recruitRepository.increaseViewCount(recruitId, viewCountInRedis);
-
-            // Redis 값 0으로 초기화
-            redisUtil.set(key);
+        if(entries.isEmpty()) {
+            return;
         }
+
+        for(Object key : entries.keySet()) {
+            Object value = entries.get(key);
+            if(value == null)
+                continue;
+
+            Long recruitId = Long.valueOf(String.valueOf(key));
+            Long totalViewCount = Long.valueOf(String.valueOf(value));
+            recruitRepository.findById(recruitId).ifPresent(recruit -> {
+                recruitRepository.increaseViewCount(recruitId, totalViewCount);
+            });
+        }
+
+        redisTemplate.delete(TOTAL_HASH);
+
         log.info("공고문 조회수 스케줄링 작업 완료");
     }
 
@@ -67,16 +73,20 @@ public class RecruitScheduledService {
             return;
         }
 
-        Pageable pageable = PageRequest.of(0, 5);
+        LocalDateTime now = LocalDateTime.now();
+        List<Recruit> popularRecruits = recruitRepository.findTop5ByRecruitableAndDeadlineAfterOrderByDeadlineDesc(now);
 
-        Page<Recruit> recruits = recruitRepository.findByRecruitableTrueOrderByViewCountDesc(pageable);
+        log.info("공고문 로직 실행 중");
 
-        Page<RecruitPopularityResDto> results = recruits.map(r -> {
-            String mediaUrl = fileService.getMediaUrl(PostType.PROFILE, r.getMember().getId());
-            return RecruitPopularityResDto.of(r, mediaUrl);
-        });
+        List<RecruitPopularityResDto> results = popularRecruits.stream().map(
+                r -> {
+                    String mediaUrl = fileService.getMediaUrl(PostType.PROFILE, r.getMember().getId());
+                    return RecruitPopularityResDto.of(r, mediaUrl);
+                }
+        ).toList();
+        log.info("popular Recruit size: {}", results.size());
 
-        cache.put(buildKey(pageable), results.getContent());
+        cache.put("recruit:popular", results);
     }
 
     private String buildKey(Pageable pageable) {

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitService.java
@@ -28,7 +28,7 @@ public interface RecruitService {
 
     void deleteRecruit(String email, Long recruitId);
 
-    List<RecruitPopularityResDto> getPopularRecruits(Pageable pageable);
+    List<RecruitPopularityResDto> getPopularRecruits();
 
     void updateRecruitable(Long recruitId, MemberIdReqDto reqDto);
 }

--- a/src/main/java/com/souf/soufwebsite/global/config/RedisConfig.java
+++ b/src/main/java/com/souf/soufwebsite/global/config/RedisConfig.java
@@ -11,6 +11,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -31,6 +32,11 @@ public class RedisConfig {
         config.setHostName(redisProperties.getHost());
         config.setPassword(redisProperties.getPassword());
         return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
     }
 
     @Bean

--- a/src/main/java/com/souf/soufwebsite/global/redis/service/DistributedLockService.java
+++ b/src/main/java/com/souf/soufwebsite/global/redis/service/DistributedLockService.java
@@ -24,12 +24,19 @@ public class DistributedLockService {
     private final ViewCountService viewCountService;
     private final SlackService slackService;
 
+    /* ------------------------------ Feed --------------------------------------- */
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void syncFeedView(){
-        distributedLock("sync:feed:lock", feedScheduledService::syncViewCountsToDB);
+        distributedLock("sync:total:feed:lock", feedScheduledService::syncTotalViewCountsToDB);
+    }
+
+    @Scheduled(cron = "0 5 0 * * 1")
+    public void syncFeedWeeklyView(){
+        distributedLock("sync:feed:lock", feedScheduledService::syncWeeklyViewCountsToDB);
         distributedLock("sync:popular:feed:lock", feedScheduledService::refreshPopularFeeds);
     }
 
+    /* --------------------------------- Recruit --------------------------------- */
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void syncRecruitView(){
         distributedLock("sync:recruit:lock", recruitScheduledService::syncViewCountsToDB);
@@ -65,7 +72,7 @@ public class DistributedLockService {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error("락 대기 중 인터럽트 발생", e);
-            slackService.sendSlackMessage("스케줄 작업 중 오류가 발생했어요!", "error");
+            slackService.sendSlackMessage("스케줄링 작업 중 현재 스레드에서 오류가 발생했어요!", "error");
         } catch (Exception e) {
             log.error("스케줄 작업 중 예외 발생", e);
             slackService.sendSlackMessage("스케줄 작업 중 오류가 발생했어요!", "error");

--- a/src/main/java/com/souf/soufwebsite/global/redis/util/CacheWarmUpRunner.java
+++ b/src/main/java/com/souf/soufwebsite/global/redis/util/CacheWarmUpRunner.java
@@ -21,8 +21,8 @@ public class CacheWarmUpRunner implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) throws Exception {
         viewCountService.refreshViewCountCache();
-        feedScheduledService.refreshPopularFeeds();
-        recruitScheduledService.refreshPopularRecruits();
+//        feedScheduledService.refreshPopularFeeds();
+//        recruitScheduledService.refreshPopularRecruits();
         log.info("인기 게시글 캐싱 완료");
     }
 }

--- a/src/main/java/com/souf/soufwebsite/global/redis/util/RedisUtil.java
+++ b/src/main/java/com/souf/soufwebsite/global/redis/util/RedisUtil.java
@@ -2,6 +2,7 @@ package com.souf.soufwebsite.global.redis.util;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -12,6 +13,7 @@ import java.util.Set;
 public class RedisUtil {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
 
     public void set(String key) {
         redisTemplate.opsForValue().set(key, 0L);
@@ -35,7 +37,6 @@ public class RedisUtil {
     public void increaseCount(String key){
         redisTemplate.opsForValue().increment(key);
     }
-
     public void deleteKey(String key){
         redisTemplate.delete(key);
     }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- close #216 

## 구현 내용
- [x] 이슈에 기입된 사항들을 모두 충족했나요?
- 메인 페이지에 기재되어 있는 인기 게시글에 대한 DB 접근을 최소화하기 위해서 Spring Cache를 도입하여 응답 속도와 접근 범위를 최소화하였습니다.(200ms -> 20ms)
  - 기존 클라이언트에 페이징 방식으로 3페이지까지 저장하였던 피드/공고문은 리뉴얼된 메인 페이지로 인해 1페이지로 축소되어 Page 대신 List 형태로 제공하였습니다.
  - 인기 공고문의 경우에는 누적 조회수 순으로 제공하였으나, 사용자에게 더욱 효과적인 정보 제공을 위해 마감 임박순으로 정렬하고 5개를 제공하였습니다.
  - StringRedisTemplate를 도입하였는데 이유는 다음과 같습니다.
    1. 직렬화
    2. RedisTemplate과 달리 자동으로 숫자 연산 기능 제공 
    3. 비용 절감

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
- 주간 조회수를 의미하는 키를 가진 모든 해시 키를 조회한 후에 값을 추출하여 실제 DB에 저장하는 스케줄링 작업을 실행하였습니다.
- 피드/공고문 스케줄링 작업은 다음과 같습니다.
  - 누적 조회수 DB에 저장 => 매 00시
  - 주간 조회수 DB에 저장 => 매 월요일 00시
<img width="982" height="618" alt="image" src="https://github.com/user-attachments/assets/e541212e-d1db-464f-a5a8-f51e1ca91b16" />
<img width="644" height="530" alt="image" src="https://github.com/user-attachments/assets/4b29b3b2-5bdc-4263-90ac-4c7969118400" />
