### PR TITLE
Hot fix: 공고문피드 생성 로직 오류 핫픽스

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedReqDto.java
@@ -21,11 +21,11 @@ public record FeedReqDto(
         List<String> existingImageUrls,
 
         @Schema(description = "원본 파일 이름", example = "[fileName.jpg, dog.jpg..]")
-        @NotNull(message = "없더라도 빈 값을 넣어주세요.")
+        @NotNull(message = "첨부할 이미지가 없더라도 빈 값을 넣어주세요.")
         List<String> originalFileNames,
 
         @Schema(description = "카테고리 목록", implementation = CategoryDto.class)
-        @NotEmpty(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
+        @NotNull(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
         List<CategoryDto> categoryDtos
         ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedUpdateReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/dto/FeedUpdateReqDto.java
@@ -1,9 +1,0 @@
-package com.souf.soufwebsite.domain.feed.dto;
-
-import java.util.List;
-
-public record FeedUpdateReqDto(
-        String content,
-
-        List<Long> keepFileIds
-) {}

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/SortOption.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/SortOption.java
@@ -10,6 +10,10 @@ public record SortOption<T extends Enum<T>>(
 ) {
     public enum SortDir { ASC, DESC }
 
+    public SortOption {
+        if (sortDir == null) sortDir = SortDir.DESC;
+    }
+
     public T sortKeyOrDefault(T defaultKey) {
         return sortKey == null ? defaultKey : sortKey;
     }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/MyRecruitReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/MyRecruitReqDto.java
@@ -6,4 +6,12 @@ import com.souf.soufwebsite.domain.recruit.entity.MyRecruitSortKey;
 
 public record MyRecruitReqDto(
         SortOption<MyRecruitSortKey> sortOption
-) {}
+) {
+    public MyRecruitReqDto {
+        if (sortOption == null) {
+            sortOption = new SortOption<>(MyRecruitSortKey.RECENT, SortOption.SortDir.DESC);
+        } else if (sortOption.sortKey() == null) {
+            sortOption = new SortOption<>(MyRecruitSortKey.RECENT, sortOption.sortDir());
+        }
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/RecruitReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/RecruitReqDto.java
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.souf.soufwebsite.domain.recruit.entity.WorkType;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,20 +16,25 @@ public record RecruitReqDto(
         String title,
 
         @Schema(description = "공고문 내용", example = "공고문 내용...")
-        @NotNull(message = "공고문 내용은 필수입니다.")
-        @Size(min = 1)
+        @NotBlank(message = "공고문 내용은 필수입니다.")
         String content,
 
         @Schema(description = "지역 ID", example = "1")
-        @NotBlank(message = "지역은 필수입니다.")
+        @NotNull(message = "지역은 필수입니다.")
         Long cityId,
 
         @Schema(description = "세부 지역 ID", example = "1")
         Long cityDetailId,
 
+        @Schema(description = "채용 시작일", example = "2025-06-23T13:29")
+        @PastOrPresent
+        @NotNull(message = "채용 시작일은 필수입니다.")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
+        LocalDateTime startDate,
+
         @Schema(description = "마감 기한", example = "2025-06-23T13:29")
         @Future
-        @NotBlank(message = "마감 기한은 필수입니다.")
+        @NotNull(message = "마감 기한은 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
         LocalDateTime deadline,
 
@@ -44,17 +46,18 @@ public record RecruitReqDto(
         String preferentialTreatment,
 
         @Schema(description = "카테고리 목록", implementation = CategoryDto.class)
-        @NotBlank(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
+        @NotEmpty(message = "적어도 한 개의 카테고리가 들어있어야 합니다.")
         List<CategoryDto> categoryDtos,
 
         @Schema(description = "기존에 존재하는 파일 URL", example = "[\"https://s3.../img1.jpg\", \"https://s3.../img2.jpg\"]")
         List<String> existingImageUrls,
 
         @Schema(description = "원본 파일 이름 리스트, 없으면 [] 이렇게 빈 리스트로 반환해주세요.", example = "[\"fileName.jpg\", \"dog.jpg\"]")
+        @NotNull(message = "첨부할 파일이 없으면 빈 리스트를 주세요")
         List<String> originalFileNames,
 
         @Schema(description = "업무 형태를 넣어주세요.", example = "OFFLINE or ONLINE")
-        @NotBlank(message = "업무 형태를 반드시 지정해주세요.")
+        @NotNull(message = "업무 형태를 반드시 지정해주세요.")
         WorkType workType
 ) {
 }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/RecruitSearchReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/RecruitSearchReqDto.java
@@ -8,4 +8,12 @@ public record RecruitSearchReqDto(
         @Schema(description = "제목") String title,
         @Schema(description = "내용") String content,
         SortOption<RecruitSortKey> sortOption
-) {}
+) {
+    public RecruitSearchReqDto {
+        if (sortOption == null) {
+            sortOption = new SortOption<>(RecruitSortKey.RECENT, SortOption.SortDir.DESC);
+        } else if (sortOption.sortKey() == null) {
+            sortOption = new SortOption<>(RecruitSortKey.RECENT, sortOption.sortDir());
+        }
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/entity/Recruit.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/entity/Recruit.java
@@ -83,6 +83,7 @@ public class Recruit extends BaseEntity {
                 .content(reqDto.content())
                 .city(city)
                 .cityDetail(cityDetail)
+                .startTime(reqDto.startDate())
                 .deadline(reqDto.deadline())
                 .price(reqDto.price())
                 .preferentialTreatment(reqDto.preferentialTreatment())

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/entity/Recruit.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/entity/Recruit.java
@@ -41,8 +41,8 @@ public class Recruit extends BaseEntity {
     @JoinColumn(name = "cityDetail_id")
     private CityDetail cityDetail;
 
-    @Column
-    private LocalDateTime startTime;
+    @Column(nullable = true)
+    private LocalDateTime startDate;
 
     // 마감일자
     @Column
@@ -83,7 +83,7 @@ public class Recruit extends BaseEntity {
                 .content(reqDto.content())
                 .city(city)
                 .cityDetail(cityDetail)
-                .startTime(reqDto.startDate())
+                .startDate(reqDto.startDate())
                 .deadline(reqDto.deadline())
                 .price(reqDto.price())
                 .preferentialTreatment(reqDto.preferentialTreatment())


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- close #221 

## 구현 내용
- [x] 이슈에 기입된 사항들을 모두 충족했나요?
 reqDto에 오용된 유효성 검사에 대해 수정 완료

## 참고 자료
- validation 어노테이션은 request 데이터에 대해 @NotNull, @NotEmpty, @NotBlank가 주로 사용된다.
- 이때 NotBlank는 String 값에 대해서 유효성 검증을 진행하기 때문에 LocalDateTime이나 Enum 클래스를 사용하게 된다면 서버에서는 불일치한다는 판단을 내리게 된다.
- 때문에 이러한 필드들에 대해 NotBlank가 아닌 NotNull을 사용하여 오류를 해결하였다.
<img width="995" height="726" alt="image" src="https://github.com/user-attachments/assets/9c5e1f7c-5fcf-4e8e-966c-78a2ca9e4f44" />

