### PR TITLE
[FEAT] 공고문 조회 기능 구체화

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
@@ -33,10 +33,7 @@ public interface RecruitApiSpecification {
 
     @Operation(summary = "공고문 리스트 조회", description = "카테고리에 걸맞는 공고문 리스트를 조회합니다.")
     @GetMapping
-    SuccessResponse<Page<RecruitSimpleResDto>> getRecruits(@RequestParam(name = "firstCategory") Long first,
-                                                           @RequestParam(name = "secondCategory") Long second,
-                                                           @RequestParam(name = "thirdCategory") Long third,
-                                                           @RequestBody RecruitSearchReqDto recruitSearchReqDto,
+    SuccessResponse<Page<RecruitSimpleResDto>> getRecruits(@RequestBody RecruitSearchReqDto recruitSearchReqDto,
                                                            @PageableDefault(size = 12) Pageable pageable);
 
     @Operation(summary = "특정 공고문 상세 조회", description = "특정 공고문에 대한 상세 정보를 조회합니다.")

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
@@ -47,15 +47,12 @@ public class RecruitController implements RecruitApiSpecification{
         return new SuccessResponse(RECRUIT_FILE_METADATA_CREATE.getMessage());
     }
 
-    @GetMapping
+    @PostMapping("/search")
     public SuccessResponse<Page<RecruitSimpleResDto>> getRecruits(
-            @RequestParam(required = false, name = "firstCategory") Long first,
-            @RequestParam(required = false, name = "secondCategory") Long second,
-            @RequestParam(required = false, name = "thirdCategory") Long third,
-            @ModelAttribute RecruitSearchReqDto recruitSearchReqDto,
+            @RequestBody RecruitSearchReqDto recruitSearchReqDto,
             @PageableDefault(size = 12) Pageable pageable) {
         return new SuccessResponse<>(
-                recruitService.getRecruits(first, second, third, recruitSearchReqDto, pageable),
+                recruitService.getRecruits(recruitSearchReqDto, pageable),
                 RECRUIT_GET.getMessage());
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/RecruitSearchReqDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/req/RecruitSearchReqDto.java
@@ -2,10 +2,14 @@ package com.souf.soufwebsite.domain.recruit.dto.req;
 
 import com.souf.soufwebsite.domain.recruit.dto.SortOption;
 import com.souf.soufwebsite.domain.recruit.entity.RecruitSortKey;
+import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
 
 public record RecruitSearchReqDto(
         @Schema(description = "제목") String title,
         @Schema(description = "내용") String content,
+        List<CategoryDto> categories,
         SortOption<RecruitSortKey> sortOption
 ) {}

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepository.java
@@ -10,8 +10,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface RecruitCustomRepository {
 
-    Page<RecruitSimpleResDto> getRecruitList(Long first, Long second, Long third,
-                                             RecruitSearchReqDto searchReqDto, Pageable pageable);
+    Page<RecruitSimpleResDto> getRecruitList(RecruitSearchReqDto searchReqDto, Pageable pageable);
 
     Page<MyRecruitResDto> getMyRecruits(Member me, MyRecruitReqDto reqDto, Pageable pageable);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepositoryImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepositoryImpl.java
@@ -3,11 +3,12 @@ package com.souf.soufwebsite.domain.recruit.repository;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.souf.soufwebsite.domain.member.entity.Member;
-import com.souf.soufwebsite.domain.member.repository.MemberRepository;
 import com.souf.soufwebsite.domain.recruit.dto.SortOption;
 import com.souf.soufwebsite.domain.recruit.dto.req.MyRecruitReqDto;
 import com.souf.soufwebsite.domain.recruit.dto.res.MyRecruitResDto;
@@ -25,10 +26,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.souf.soufwebsite.domain.recruit.entity.QRecruit.recruit;
 import static com.souf.soufwebsite.domain.recruit.entity.QRecruitCategoryMapping.recruitCategoryMapping;
@@ -41,11 +42,40 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<RecruitSimpleResDto> getRecruitList(Long first, Long second, Long third,
-                                                    RecruitSearchReqDto searchReqDto, Pageable pageable) {
+    public Page<RecruitSimpleResDto> getRecruitList(Long first,
+                                                    Long second,
+                                                    Long third,
+                                                    RecruitSearchReqDto req,
+                                                    Pageable pageable) {
 
-        OrderSpecifier<?>[] orderSpecifiers = buildOrderSpecifiers(searchReqDto);
+        // 1) 동적 where (EXISTS 기반)
+        BooleanExpression where = buildWhere(first, second, third, req);
 
+        OrderSpecifier<?>[] orderSpecifiers = buildOrderSpecifiers(req);
+
+        // STEP 1. 페이지에 들어갈 recruit.id만 정확히 선별
+        List<Long> pageIds = queryFactory
+                .select(recruit.id)
+                .from(recruit)
+                .where(where)
+                .orderBy(orderSpecifiers)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (pageIds.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+
+        // 총 개수
+        Long total = queryFactory
+                .select(recruit.id.countDistinct())
+                .from(recruit)
+                .where(where)
+                .fetchOne();
+        long totalCount = total == null ? 0L : total;
+
+        // STEP 2. 선별된 ID들로 상세 재조회(조인/병합)
         List<Tuple> tuples = queryFactory
                 .select(
                         recruit.id,
@@ -65,57 +95,46 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
                 .join(recruit.categories, recruitCategoryMapping)
                 .leftJoin(recruit.city)
                 .leftJoin(recruit.cityDetail)
-                .where(
-                        first != null ? recruitCategoryMapping.firstCategory.id.eq(first) : null,
-                        second != null ? recruitCategoryMapping.secondCategory.id.eq(second) : null,
-                        third != null ? recruitCategoryMapping.thirdCategory.id.eq(third) : null,
-                        searchReqDto.title() != null ? recruit.title.contains(searchReqDto.title()) : null,
-                        searchReqDto.content() != null ? recruit.content.contains(searchReqDto.content()) : null
-                )
-                .orderBy(orderSpecifiers)
+                .where(recruit.id.in(pageIds))
                 .fetch();
 
-        // 중복 제거 및 병합 처리
-        Map<Long, RecruitSimpleResDto> mergedMap = new LinkedHashMap<>();
-
+        // 병합
+        Map<Long, RecruitSimpleResDto> byId = new LinkedHashMap<>();
         for (Tuple t : tuples) {
-            Long recruitId = t.get(recruit.id);
-            Long secondCatId = t.get(recruitCategoryMapping.secondCategory.id) == null
-                    ? 0L : t.get(recruitCategoryMapping.secondCategory.id);
+            Long id = t.get(recruit.id);
+            Long secondCatId = Optional.ofNullable(t.get(recruitCategoryMapping.secondCategory.id)).orElse(0L);
 
-            if (!mergedMap.containsKey(recruitId)) {
-                String cityName = Optional.ofNullable(t.get(recruit.city.name)).orElse("");
-                String cityDetailName = Optional.ofNullable(t.get(recruit.cityDetail.name)).orElse("");
+            if (!byId.containsKey(id)) {
+                String city = Optional.ofNullable(t.get(recruit.city.name)).orElse("");
+                String cityDetail = Optional.ofNullable(t.get(recruit.cityDetail.name)).orElse("");
 
                 RecruitSimpleResDto dto = RecruitSimpleResDto.of(
-                        recruitId,
+                        id,
                         t.get(recruit.title),
                         secondCatId,
                         t.get(recruit.content),
                         t.get(recruit.minPayment),
                         t.get(recruit.maxPayment),
-                        cityName,
-                        cityDetailName,
+                        city,
+                        cityDetail,
                         t.get(recruit.deadline),
                         t.get(recruit.recruitCount),
                         Boolean.TRUE.equals(t.get(recruit.recruitable)),
                         t.get(recruit.lastModifiedTime)
                 );
-                mergedMap.put(recruitId, dto);
+                byId.put(id, dto);
             } else {
-                if(secondCatId != null)
-                    mergedMap.get(recruitId).addSecondCategory(secondCatId);
+                byId.get(id).addSecondCategory(secondCatId);
             }
         }
 
-        List<RecruitSimpleResDto> mergedList = new ArrayList<>(mergedMap.values());
+        // STEP1에서 뽑은 정렬 순서를 보존하기 위해 pageIds 순서대로 재정렬
+        List<RecruitSimpleResDto> ordered = pageIds.stream()
+                .map(byId::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
 
-        // 수동 페이징 처리
-        int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), mergedList.size());
-        List<RecruitSimpleResDto> paged = mergedList.subList(start, end);
-
-        return new PageImpl<>(paged, pageable, mergedList.size());
+        return new PageImpl<>(ordered, pageable, totalCount);
     }
 
     @Override
@@ -211,5 +230,75 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
                     new OrderSpecifier<>(Order.DESC, recruit.lastModifiedTime)
             };
         };
+    }
+
+    private BooleanExpression buildWhere(Long first, Long second, Long third, RecruitSearchReqDto req) {
+        List<BooleanExpression> ands = new ArrayList<>();
+
+        // 텍스트 필터
+        if (req.title() != null && !req.title().isBlank()) {
+            ands.add(recruit.title.contains(req.title()));
+        }
+        if (req.content() != null && !req.content().isBlank()) {
+            ands.add(recruit.content.contains(req.content()));
+        }
+
+        // 카테고리(리스트 우선)
+        if (req.categories() != null && !req.categories().isEmpty()) {
+            ands.add(buildCategoryExistsOr(req.categories()));
+        } else {
+            if (first != null)  ands.add(existsCategory(first, null, null));
+            if (second != null) ands.add(existsCategory(null, second, null));
+            if (third != null)  ands.add(existsCategory(null, null, third));
+        }
+
+        // AND 결합
+        return ands.stream().filter(Objects::nonNull).reduce(BooleanExpression::and).orElse(null);
+    }
+
+    /**
+     * (F,S,T) 조합들의 OR: 각 조합을 EXISTS(매핑 테이블)로 감싸 중복 없이 필터링
+     *  - (1-2-3) OR (2-*-*) OR (3-1-*)
+     */
+    private BooleanExpression buildCategoryExistsOr(List<CategoryDto> categories) {
+        // 최적화: 전부 first-only면 IN 사용
+        boolean onlyFirst = categories.stream().allMatch(c ->
+                c.firstCategory() != null && c.secondCategory() == null && c.thirdCategory() == null);
+
+        if (onlyFirst) {
+            List<Long> firstIds = categories.stream()
+                    .map(CategoryDto::firstCategory)
+                    .distinct()
+                    .collect(Collectors.toList());
+            return recruit.id.in(
+                    JPAExpressions
+                            .select(recruitCategoryMapping.recruit.id)
+                            .from(recruitCategoryMapping)
+                            .where(recruitCategoryMapping.firstCategory.id.in(firstIds))
+            );
+        }
+
+        // 일반: 각 조합 → EXISTS … AND 묶음 → 전체는 OR
+        List<BooleanExpression> ors = new ArrayList<>();
+        for (CategoryDto c : categories) {
+            ors.add(existsCategory(c.firstCategory(), c.secondCategory(), c.thirdCategory()));
+        }
+        return ors.stream().filter(Objects::nonNull).reduce(BooleanExpression::or).orElse(null);
+    }
+
+    private BooleanExpression existsCategory(Long first, Long second, Long third) {
+        if (first == null && second == null && third == null) {
+            return null;
+        }
+        BooleanExpression cond = recruitCategoryMapping.recruit.id.eq(recruit.id);
+        if (first != null)  cond = cond.and(recruitCategoryMapping.firstCategory.id.eq(first));
+        if (second != null) cond = cond.and(recruitCategoryMapping.secondCategory.id.eq(second));
+        if (third != null)  cond = cond.and(recruitCategoryMapping.thirdCategory.id.eq(third));
+
+        return JPAExpressions
+                .selectOne()
+                .from(recruitCategoryMapping)
+                .where(cond)
+                .exists();
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepositoryImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.souf.soufwebsite.domain.member.repository.MemberRepository;
 import com.souf.soufwebsite.domain.recruit.dto.SortOption;
 import com.souf.soufwebsite.domain.recruit.dto.req.MyRecruitReqDto;
 import com.souf.soufwebsite.domain.recruit.dto.req.RecruitSearchReqDto;
+import com.souf.soufwebsite.domain.recruit.dto.res.MyRecruitResDto;
 import com.souf.soufwebsite.domain.recruit.dto.res.RecruitSimpleResDto;
 import com.souf.soufwebsite.domain.recruit.entity.MyRecruitSortKey;
 import com.souf.soufwebsite.domain.recruit.entity.Recruit;
@@ -42,14 +43,11 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<RecruitSimpleResDto> getRecruitList(Long first,
-                                                    Long second,
-                                                    Long third,
-                                                    RecruitSearchReqDto req,
+    public Page<RecruitSimpleResDto> getRecruitList(RecruitSearchReqDto req,
                                                     Pageable pageable) {
 
         // 1) 동적 where (EXISTS 기반)
-        BooleanExpression where = buildWhere(first, second, third, req);
+        BooleanExpression where = buildWhere(req);
 
         OrderSpecifier<?>[] orderSpecifiers = buildOrderSpecifiers(req);
 
@@ -112,11 +110,9 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
                         t.get(recruit.title),
                         secondCatId,
                         t.get(recruit.content),
-                        t.get(recruit.minPayment),
-                        t.get(recruit.maxPayment),
+                        t.get(recruit.price),
                         city,
                         cityDetail,
-                        t.get(recruit.price),
                         t.get(recruit.deadline),
                         t.get(recruit.recruitCount),
                         Boolean.TRUE.equals(t.get(recruit.recruitable)),
@@ -232,7 +228,7 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
         };
     }
 
-    private BooleanExpression buildWhere(Long first, Long second, Long third, RecruitSearchReqDto req) {
+    private BooleanExpression buildWhere(RecruitSearchReqDto req) {
         List<BooleanExpression> ands = new ArrayList<>();
 
         // 텍스트 필터
@@ -246,10 +242,6 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
         // 카테고리(리스트 우선)
         if (req.categories() != null && !req.categories().isEmpty()) {
             ands.add(buildCategoryExistsOr(req.categories()));
-        } else {
-            if (first != null)  ands.add(existsCategory(first, null, null));
-            if (second != null) ands.add(existsCategory(null, second, null));
-            if (third != null)  ands.add(existsCategory(null, null, third));
         }
 
         // AND 결합

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitService.java
@@ -17,8 +17,7 @@ public interface RecruitService {
 
     void uploadRecruitMedia(MediaReqDto reqDto);
 
-    Page<RecruitSimpleResDto> getRecruits(Long first, Long second, Long third,
-                                          RecruitSearchReqDto searchReqDto, Pageable pageable);
+    Page<RecruitSimpleResDto> getRecruits(RecruitSearchReqDto searchReqDto, Pageable pageable);
 
     Page<MyRecruitResDto> getMyRecruits(String email, MyRecruitReqDto reqDto, Pageable pageable);
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
@@ -103,18 +103,13 @@ public class RecruitServiceImpl implements RecruitService {
 
     @Transactional(readOnly = true)
     @Override
-    public Page<RecruitSimpleResDto> getRecruits(Long first,
-                                                 Long second,
-                                                 Long third,
-                                                 RecruitSearchReqDto reqDto,
+    public Page<RecruitSimpleResDto> getRecruits(RecruitSearchReqDto reqDto,
                                                  Pageable pageable) {
         if (reqDto.categories() != null && !reqDto.categories().isEmpty()) {
             categoryService.validate(reqDto.categories());
-        } else {
-            categoryService.validate(first, second, third);
         }
 
-        return recruitRepository.getRecruitList(first, second, third, reqDto, pageable);
+        return recruitRepository.getRecruitList(reqDto, pageable);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
@@ -104,7 +104,11 @@ public class RecruitServiceImpl implements RecruitService {
                                                  Long third,
                                                  RecruitSearchReqDto reqDto,
                                                  Pageable pageable) {
-        categoryService.validate(first, second, third);
+        if (reqDto.categories() != null && !reqDto.categories().isEmpty()) {
+            categoryService.validate(reqDto.categories());
+        } else {
+            categoryService.validate(first, second, third);
+        }
 
         return recruitRepository.getRecruitList(first, second, third, reqDto, pageable);
     }

--- a/src/main/java/com/souf/soufwebsite/global/common/category/service/CategoryService.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/category/service/CategoryService.java
@@ -1,5 +1,6 @@
 package com.souf.soufwebsite.global.common.category.service;
 
+import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
 import com.souf.soufwebsite.global.common.category.entity.FirstCategory;
 import com.souf.soufwebsite.global.common.category.entity.SecondCategory;
 import com.souf.soufwebsite.global.common.category.entity.ThirdCategory;
@@ -9,6 +10,8 @@ import com.souf.soufwebsite.global.common.category.repository.SecondCategoryRepo
 import com.souf.soufwebsite.global.common.category.repository.ThirdCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -55,6 +58,16 @@ public class CategoryService {
 
         if (firstId != null && !firstCategoryRepository.existsById(firstId)) {
             throw new NotFoundFirstCategoryException();
+        }
+    }
+
+    public void validate(List<CategoryDto> categories) {
+        if (categories == null || categories.isEmpty()) {
+            throw new IllegalArgumentException("카테고리 조합이 비어 있습니다.");
+        }
+
+        for (CategoryDto c : categories) {
+            validate(c.firstCategory(), c.secondCategory(), c.thirdCategory());
         }
     }
 }


### PR DESCRIPTION
## 개요
공고문 조회에서 카테고리를 여러가지 선택(체크박스 등)해서 공고문을 조회할 수 있도록 함

## 진행한 이슈
- close #214

## 구현 내용
- [ ] 카테고리 선택에 있어서 중복으로 적용되는 것을 막기 위해 BooleanExpression 을 사용하였습니다,
- [ ] GET 메서드로 구성하려 했을 때, api 호출 uri가 과도하게 길어지는 문제가 있었습니다. 하지만, 조회 기능임에도 불구하고 POST 메서드로 작성하는 것이 맞는가에 대한 의문이 있었습니다. elasticsearch, graphql 등의 검색 관련 오픈소스에서도 post 메서드를 사용하는 것에 착안하여 post 매핑 후, requestBody로 카테고리 정보를 넘기는 방식을 선택하였습니다.
<img width="672" height="215" alt="image" src="https://github.com/user-attachments/assets/771bbb65-48da-40a0-a814-fa1dfd8f01a8" />
<img width="677" height="374" alt="image" src="https://github.com/user-attachments/assets/0f19c8f7-13d8-46a6-b865-e14fce940c80" />


## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
