### PR TITLE
Feat: 게시글 조회 수 중복방지 기능 구현

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedApiSpecification.java
@@ -6,6 +6,7 @@ import com.souf.soufwebsite.global.success.SuccessResponse;
 import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -37,7 +38,9 @@ public interface FeedApiSpecification {
     @GetMapping("/{memberId}/{feedId}")
     SuccessResponse<FeedDetailResDto> getDetailedFeed(
             @PathVariable(name = "memberId") Long memberId,
-            @PathVariable(name = "feedId") Long feedId);
+            @PathVariable(name = "feedId") Long feedId,
+            HttpServletRequest request
+    );
 
     @Operation(summary = "특정 피드 수정", description = "사용자 본인이 소유한 피드에 대해 수정합니다.")
     @PatchMapping("/{feedId}")

--- a/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/controller/FeedController.java
@@ -5,6 +5,7 @@ import com.souf.soufwebsite.domain.feed.service.FeedService;
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import com.souf.soufwebsite.global.util.CurrentEmail;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,9 +52,15 @@ public class FeedController implements FeedApiSpecification{
     @GetMapping("/{memberId}/{feedId}")
     public SuccessResponse<FeedDetailResDto> getDetailedFeed(
             @PathVariable(name = "memberId") Long memberId,
-            @PathVariable(name = "feedId") Long feedId) {
+            @PathVariable(name = "feedId") Long feedId,
+            HttpServletRequest request) {
 
-        return new SuccessResponse<>(feedService.getFeedById(memberId, feedId), FEED_GET.getMessage());
+        String ip = request.getRemoteAddr();
+        String userAgent = request.getHeader("User-Agent");
+
+        FeedDetailResDto result = feedService.getFeedById(memberId, feedId, ip, userAgent);
+
+        return new SuccessResponse<>(result, FEED_GET.getMessage());
     }
 
     @PatchMapping("/{feedId}")

--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedService.java
@@ -15,7 +15,7 @@ public interface FeedService {
 
     MemberFeedResDto getStudentFeeds(Long memberId, Pageable pageable);
 
-    FeedDetailResDto getFeedById(Long memberId, Long feedId);
+    FeedDetailResDto getFeedById(Long memberId, Long feedId, String ip, String userAgent);
 
     FeedResDto updateFeed(String email, Long feedId, FeedReqDto reqDto);
 

--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
@@ -310,7 +310,7 @@ public class FeedServiceImpl implements FeedService {
                     + feed.getViewCount();
         }
 
-        log.info("조회수 중복 방지");
+        log.info("피드 조회수 중복 방지");
         Object viewCount = stringRedisTemplate.opsForHash().get(TOTAL_HASH, String.valueOf(feedId));
         long redisFeedViewCount = 0L;
         if(viewCount != null){

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitApiSpecification.java
@@ -10,6 +10,7 @@ import com.souf.soufwebsite.global.success.SuccessResponse;
 import com.souf.soufwebsite.global.util.CurrentEmail;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -41,7 +42,9 @@ public interface RecruitApiSpecification {
 
     @Operation(summary = "특정 공고문 상세 조회", description = "특정 공고문에 대한 상세 정보를 조회합니다.")
     @GetMapping("/{recruitId}")
-    SuccessResponse<RecruitResDto> getRecruitById(@PathVariable(name = "recruitId") Long recruitId);
+    SuccessResponse<RecruitResDto> getRecruitById(
+            @PathVariable(name = "recruitId") Long recruitId,
+            HttpServletRequest request);
 
     @Operation(summary = "내 공고문 리스트 조회", description = "사용자 본인이 작성한 공고문 리스트를 조회합니다.")
     @GetMapping("/my")

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/controller/RecruitController.java
@@ -10,6 +10,7 @@ import com.souf.soufwebsite.domain.recruit.service.RecruitService;
 import com.souf.soufwebsite.global.redis.util.RedisUtil;
 import com.souf.soufwebsite.global.success.SuccessResponse;
 import com.souf.soufwebsite.global.util.CurrentEmail;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,9 +61,16 @@ public class RecruitController implements RecruitApiSpecification{
     }
 
     @GetMapping("/{recruitId}")
-    public SuccessResponse<RecruitResDto> getRecruitById(@PathVariable(name = "recruitId") Long recruitId) {
+    public SuccessResponse<RecruitResDto> getRecruitById(
+            @PathVariable(name = "recruitId") Long recruitId,
+            HttpServletRequest request) {
+
+        String ip = request.getRemoteAddr();
+        String userAgent = request.getHeader("User-Agent");
+        RecruitResDto result = recruitService.getRecruitById(recruitId, ip, userAgent);
+
         return new SuccessResponse<>(
-                recruitService.getRecruitById(recruitId),
+                result,
                 RECRUIT_GET.getMessage());
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitService.java
@@ -22,7 +22,7 @@ public interface RecruitService {
 
     Page<MyRecruitResDto> getMyRecruits(String email, MyRecruitReqDto reqDto, Pageable pageable);
 
-    RecruitResDto getRecruitById(Long recruitId);
+    RecruitResDto getRecruitById(Long recruitId, String ip, String userAgent);
 
     RecruitCreateResDto updateRecruit(String email, Long recruitId, RecruitReqDto reqDto);
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
@@ -35,6 +35,7 @@ import com.souf.soufwebsite.global.common.category.entity.ThirdCategory;
 import com.souf.soufwebsite.global.common.category.service.CategoryService;
 import com.souf.soufwebsite.global.redis.util.RedisUtil;
 import com.souf.soufwebsite.global.slack.service.SlackService;
+import com.souf.soufwebsite.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -44,6 +45,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -64,6 +66,10 @@ public class RecruitServiceImpl implements RecruitService {
     private final StringRedisTemplate stringRedisTemplate;
 
     public static final String TOTAL_HASH = "recruit:views:total:";
+
+    public Member getCurrentMember() {
+        return SecurityUtils.getCurrentMemberOrNull();
+    }
 
     @Override
     @Transactional
@@ -115,12 +121,13 @@ public class RecruitServiceImpl implements RecruitService {
 
     @Transactional(readOnly = true)
     @Override
-    public RecruitResDto getRecruitById(Long recruitId) {
+    public RecruitResDto getRecruitById(Long recruitId, String ip, String userAgent) {
+        Member currentMember = getCurrentMember();
+
         Recruit recruit = findIfRecruitExist(recruitId);
         Member recruitMember = recruit.getMember();
 
-        long totalViewCount = stringRedisTemplate.opsForHash().increment(TOTAL_HASH, String.valueOf(recruit.getId()), 1L)
-                + recruit.getViewCount();
+        long totalViewCount = updateTotalViewCount(currentMember, recruit, ip, userAgent);
 
         List<Media> mediaList = fileService.getMediaList(PostType.RECRUIT, recruitId);
 
@@ -260,6 +267,34 @@ public class RecruitServiceImpl implements RecruitService {
                 fileService.deleteMedia(media);  // DB에서만 삭제되도록 수정
             }
         }
+    }
+
+    private long updateTotalViewCount(Member member, Recruit recruit, String ip, String userAgent) {
+
+        String userKey;
+        if(member != null){
+            userKey = "member:" + member.getId();
+        } else {
+            userKey = "guest:" + ip + ":" + userAgent.hashCode();
+        }
+
+        String redisKey = "recruit:view:" + recruit.getId() + ":" +userKey;
+
+        Boolean isNew = stringRedisTemplate.opsForValue().setIfAbsent(redisKey, "1", Duration.ofMinutes(30));
+
+        if (Boolean.TRUE.equals(isNew)){
+            return stringRedisTemplate.opsForHash().increment(TOTAL_HASH, String.valueOf(recruit.getId()), 1L)
+                    + recruit.getViewCount();
+        }
+
+        log.info("공고문 조회수 중복 방지");
+        Object viewCount = stringRedisTemplate.opsForHash().get(TOTAL_HASH, String.valueOf(recruit.getId()));
+        long redisFeedViewCount = 0L;
+        if(viewCount != null){
+            redisFeedViewCount = Long.parseLong(viewCount.toString());
+        }
+
+        return redisFeedViewCount + recruit.getViewCount();
     }
 
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- close #225 

## 구현 내용
- [x] 이슈에 기입된 사항들을 모두 충족했나요?
1. 피드/공고문에 대한 조회 중복 방지 기능을 도입
  1. 조회수 중복을 허용하는 경우에는 서비스적으로 인기글이나 광고에 영향을 줄 뿐만 아니라, 후에 있을 추천 알고리즘 기능에도 잘못된 학습을 야기할 수 있기 때문에 중복 방지 기능을 도입하기로 했습니다.
  2. 회원/비회원 모두가 상세조회가 가능한 점을 고려하여, 회원은 memberId를, 비회원은 IP와 userAgent의 값을 복합적으로 만들어 redis에 저장하여 일정 시간 동안 조회수 증가에 대한 검사 로직을 추가하였습니다.

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
<img width="854" height="334" alt="image" src="https://github.com/user-attachments/assets/cd463a6d-8cf6-49ea-b8d3-d6324903db90" />
위와 같이 로그인 유무에 따라 userKey를 다르게 생성하여 redis에 저장하였습니다.
