### PR TITLE
[FIX] 공고문 조회 시 startDate에 대한 변수명 불일치로 인한 오류 수정

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitSimpleResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/dto/res/RecruitSimpleResDto.java
@@ -22,13 +22,13 @@ public record RecruitSimpleResDto(
 ) {
     public static RecruitSimpleResDto of(Long recruitId, String title, Long secondCategoryId, String content,
                                          String price, String cityName, String cityDetailName,
-                                         LocalDateTime startTime, LocalDateTime deadLine,
+                                         LocalDateTime startDate, LocalDateTime deadLine,
                                          Long recruitCount, boolean recruitable, LocalDateTime lastModified) {
         return new RecruitSimpleResDto(
                 recruitId, title,
                 new ArrayList<>(List.of(secondCategoryId)), // 초기 리스트
                 content, price, cityName, cityDetailName,
-                convertToDateTime(startTime), convertToDateTime(deadLine), recruitCount, recruitable, lastModified
+                convertToDateTime(startDate), convertToDateTime(deadLine), recruitCount, recruitable, lastModified
         );
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/entity/Recruit.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/entity/Recruit.java
@@ -44,7 +44,7 @@ public class Recruit extends BaseEntity {
     @JoinColumn(name = "cityDetail_id")
     private CityDetail cityDetail;
 
-    @Column(nullable = true)
+    @Column
     private LocalDateTime startDate;
 
     // 마감일자

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepositoryImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/repository/RecruitCustomRepositoryImpl.java
@@ -82,6 +82,7 @@ public class RecruitCustomRepositoryImpl implements RecruitCustomRepository{
                         recruit.price,
                         recruit.city.name,
                         recruit.cityDetail.name,
+                        recruit.startDate,
                         recruit.deadline,
                         recruit.recruitCount,
                         recruit.recruitable,

--- a/src/main/java/com/souf/soufwebsite/global/config/SecurityConfig.java
+++ b/src/main/java/com/souf/soufwebsite/global/config/SecurityConfig.java
@@ -89,6 +89,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/auth/**").permitAll()
                                 .requestMatchers("/api/v1/social/**").permitAll()
                                 .requestMatchers("/api/v1/recruit/popular", "/api/v1/feed/popular", "/api/v1/member").permitAll()
+                                .requestMatchers("/api/v1/recruit/search").permitAll()
 
                                 // 1) 인증 필요한 특정 GET (더 구체적인 경로를 먼저!)
                                 .requestMatchers(HttpMethod.GET,


### PR DESCRIPTION
## 개요
공고문 조회 시 startDate에 대한 변수명 불일치로 인한 오류 수정

## 진행한 이슈
- close #224 

## 구현 내용
- [ ] SecurityConfig 설정 수정
- [ ] startDate 변수명 통일

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
