### PR TITLE
Fix: 학생 리스트 조회 반환 데이터 수정

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberApiSpecification.java
@@ -26,7 +26,6 @@ public interface MemberApiSpecification {
             @RequestParam(name = "firstCategory") Long first,
             @RequestParam(name = "secondCategory", required = false) Long second,
             @RequestParam(name = "thirdCategory", required = false) Long third,
-            @RequestParam String keyword,
             @PageableDefault(size = 6) Pageable pageable
     );
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.souf.soufwebsite.domain.member.controller;
 
 import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
-import com.souf.soufwebsite.domain.member.dto.ReqDto.MemberSearchReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.SendModifyEmailReqDto;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.UpdateReqDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
@@ -31,11 +30,9 @@ public class MemberController implements MemberApiSpecification{
             @RequestParam(name = "firstCategory", required = false) Long first,
             @RequestParam(name = "secondCategory", required = false) Long second,
             @RequestParam(name = "thirdCategory", required = false) Long third,
-            @RequestParam(name = "keyword", required = false) String keyword,
             @PageableDefault(size = 6) Pageable pageable) {
 
-        MemberSearchReqDto reqDto = new MemberSearchReqDto(keyword);
-        return new SuccessResponse<>(memberService.getMembers(first, second, third, reqDto, pageable),
+        return new SuccessResponse<>(memberService.getMembers(first, second, third, pageable),
                 "멤버 목록을 조회했습니다.");
     }
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/dto/ResDto/MemberSimpleResDto.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/dto/ResDto/MemberSimpleResDto.java
@@ -1,15 +1,45 @@
 package com.souf.soufwebsite.domain.member.dto.ResDto;
 
+import com.souf.soufwebsite.domain.member.entity.Member;
+import com.souf.soufwebsite.domain.member.entity.MemberCategoryMapping;
+import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record MemberSimpleResDto(
         Long memberId,
+        Double temperature,
         String profileImageUrl,
         String nickname,
         String intro,
+        List<CategoryDto> categoryDtoList,
         List<PopularFeedDto> popularFeeds
 ) {
     public record PopularFeedDto(
             String imageUrl
     ) {}
+
+    public static MemberSimpleResDto from(Member member, String profileImageUrl, List<PopularFeedDto> popularFeeds, List<MemberCategoryMapping> categories) {
+        return new MemberSimpleResDto(
+                member.getId(),
+                member.getTemperature(),
+                profileImageUrl,
+                member.getNickname(),
+                member.getIntro(),
+                convertToCategoryDto(categories),
+                popularFeeds
+        );
+    }
+
+    private static List<CategoryDto> convertToCategoryDto(List<MemberCategoryMapping> mappings){
+        if(mappings == null) return new ArrayList<>();
+        return mappings.stream().map(
+                m -> new CategoryDto(
+                        m.getFirstCategory().getId(),
+                        m.getSecondCategory() != null ? m.getSecondCategory().getId() : null,
+                        m.getThirdCategory() != null ? m.getThirdCategory().getId() : null
+                )).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
@@ -16,7 +16,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Where;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -60,11 +59,11 @@ public class Member extends BaseEntity {
     @Column(length = 300)
     private String personalUrl;
 
+    @Column(nullable = false)
+    private double temperature;
+
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberCategoryMapping> categories = new ArrayList<>();
@@ -79,6 +78,7 @@ public class Member extends BaseEntity {
     @Column(name = "marketing_agreement", nullable = false)
     private boolean marketingAgreement = false;
 
+    // 누적 신고 횟수
     @Column(name = "cumulative_report_count")
     private Integer cumulativeReportCount;
 
@@ -92,6 +92,7 @@ public class Member extends BaseEntity {
         this.personalInfoAgreement = true;
         this.marketingAgreement = marketingAgreement;
         this.cumulativeReportCount = 0;
+        this.temperature = 36.5;
     }
 
     // 회원 정보 업데이트 (업데이트 가능한 필드만 반영)
@@ -150,6 +151,5 @@ public class Member extends BaseEntity {
         this.intro = "탈퇴한 회원입니다.";
         this.personalUrl = null;
         this.isDeleted = true;
-        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/repository/MemberCustomRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/repository/MemberCustomRepository.java
@@ -1,6 +1,5 @@
 package com.souf.soufwebsite.domain.member.repository;
 
-import com.souf.soufwebsite.domain.member.dto.ReqDto.MemberSearchReqDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.AdminMemberResDto;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberSimpleResDto;
 import com.souf.soufwebsite.domain.member.entity.RoleType;
@@ -11,7 +10,7 @@ public interface MemberCustomRepository {
 //    Page<Member> findByCategory(Long first, Pageable pageable);
 
     Page<MemberSimpleResDto> getMemberList(Long first, Long second, Long third,
-                                           MemberSearchReqDto searchReqDto, Pageable pageable);
+                                           Pageable pageable);
 
     Page<AdminMemberResDto> getMemberListInAdmin(RoleType memberType, String username, String nickname, Pageable pageable);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberService.java
@@ -29,7 +29,7 @@ public interface MemberService {
 
     void uploadProfileImage(MediaReqDto reqDto);
 
-    Page<MemberSimpleResDto> getMembers(Long first, Long second, Long third, MemberSearchReqDto searchReqDto, Pageable pageable);
+    Page<MemberSimpleResDto> getMembers(Long first, Long second, Long third, Pageable pageable);
 
     MemberResDto getMyInfo(String email);
 

--- a/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/service/general/MemberServiceImpl.java
@@ -304,11 +304,10 @@ public class MemberServiceImpl implements MemberService {
     @Transactional(readOnly = true)
     public Page<MemberSimpleResDto> getMembers(
             Long first, Long second, Long third,
-            MemberSearchReqDto searchReqDto,
             Pageable pageable) {
         categoryService.validate(first, second, third);
 
-        return memberRepository.getMemberList(first, second, third, searchReqDto, pageable);
+        return memberRepository.getMemberList(first, second, third, pageable);
     }
 
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- close #235 

## 구현 내용
- [ ] 이슈에 기입된 사항들을 모두 충족했나요?
학생 리스트 반환 데이터 수정
1. Member 테이블에 souf 온도 필드를 추가했습니다.
2. 학생 리스트 반환 시, souf 온도와 사용자 카테고리를 추가하였습니다.

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
DTO 변환 시 책임을 분리하여 DTO 클래스 내에서 필드를 저장하고 변환하도록 하였습니다.
<img width="856" height="400" alt="image" src="https://github.com/user-attachments/assets/a10252d6-c534-4791-b3b5-10d3bc38d67f" />
