### PR TITLE
[FEAT] 파일 첨부된 게시물 삭제 시 s3에서도 함께 삭제

### DIFF
--- a/src/main/java/com/souf/soufwebsite/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/comment/service/CommentServiceImpl.java
@@ -11,6 +11,7 @@ import com.souf.soufwebsite.domain.feed.entity.Feed;
 import com.souf.soufwebsite.domain.feed.exception.NotFoundFeedException;
 import com.souf.soufwebsite.domain.feed.repository.FeedRepository;
 import com.souf.soufwebsite.domain.file.service.FileService;
+import com.souf.soufwebsite.domain.file.service.MediaCleanupPublisher;
 import com.souf.soufwebsite.domain.member.entity.Member;
 import com.souf.soufwebsite.domain.member.exception.NotFoundMemberException;
 import com.souf.soufwebsite.domain.member.repository.MemberRepository;
@@ -32,6 +33,8 @@ public class CommentServiceImpl implements CommentService {
     private final FeedRepository feedRepository;
     private final MemberRepository memberRepository;
     private final FileService fileService;
+
+    private final MediaCleanupPublisher mediaCleanupPublisher;
 
     @Override
     public void createComment(Long postId, CommentReqDto reqDto) {
@@ -72,6 +75,8 @@ public class CommentServiceImpl implements CommentService {
         validatedIfCommentMine(member, comment); // 현재 사용자와 댓글 작성자의 아이디가 일치하지 않으면 예외 발생
 
         commentRepository.delete(comment);
+
+        mediaCleanupPublisher.publish(PostType.COMMENT, commentId);
     }
 
     @Transactional

--- a/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/feed/service/FeedServiceImpl.java
@@ -16,6 +16,7 @@ import com.souf.soufwebsite.domain.file.dto.PresignedUrlResDto;
 import com.souf.soufwebsite.domain.file.dto.video.VideoDto;
 import com.souf.soufwebsite.domain.file.entity.Media;
 import com.souf.soufwebsite.domain.file.service.FileService;
+import com.souf.soufwebsite.domain.file.service.MediaCleanupPublisher;
 import com.souf.soufwebsite.domain.member.dto.ResDto.MemberResDto;
 import com.souf.soufwebsite.domain.member.entity.Member;
 import com.souf.soufwebsite.domain.member.exception.NotFoundMemberException;
@@ -57,6 +58,7 @@ public class FeedServiceImpl implements FeedService {
     private final ViewCountService viewCountService;
     private final FeedConverter feedConverter;
     private final IndexEventPublisherHelper indexEventPublisherHelper;
+    private final MediaCleanupPublisher mediaCleanupPublisher;
     private final SlackService slackService;
     private final LikedFeedRepository likedFeedRepository;
     private final CommentRepository commentRepository;
@@ -168,6 +170,7 @@ public class FeedServiceImpl implements FeedService {
         return new FeedResDto(feed.getId(), presignedUrlResDtos, videoDto);
     }
 
+    @Transactional
     @Override
     public void deleteFeed(String email, Long feedId) {
         Member member = findIfEmailExists(email);
@@ -177,6 +180,8 @@ public class FeedServiceImpl implements FeedService {
         viewCountService.deleteViewCountFromRedis(PostType.FEED, feedId);
 
         feedRepository.delete(feed);
+
+        mediaCleanupPublisher.publish(PostType.FEED, feedId);
 
         indexEventPublisherHelper.publishIndexEvent(
                 EntityType.FEED,

--- a/src/main/java/com/souf/soufwebsite/domain/file/event/MediaCleanupEvent.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/event/MediaCleanupEvent.java
@@ -1,0 +1,5 @@
+package com.souf.soufwebsite.domain.file.event;
+
+import com.souf.soufwebsite.global.common.PostType;
+
+public record MediaCleanupEvent(PostType postType, Long postId) {}

--- a/src/main/java/com/souf/soufwebsite/domain/file/repository/MediaRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/repository/MediaRepository.java
@@ -25,5 +25,4 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
 
     List<Media> findAllByPostTypeAndPostId(PostType postType, Long postId);
 
-    List<Media> findAllByPostTypeAndPostIdIn(PostType postType, Collection<Long> postIds);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/file/repository/MediaRepository.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/repository/MediaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,4 +22,8 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
     void deleteAllByPostTypeAndPostId(PostType postType, Long postId);
 
     Optional<Media> findFirstByOriginalUrlEndingWith(String originalUrl);
+
+    List<Media> findAllByPostTypeAndPostId(PostType postType, Long postId);
+
+    List<Media> findAllByPostTypeAndPostIdIn(PostType postType, Collection<Long> postIds);
 }

--- a/src/main/java/com/souf/soufwebsite/domain/file/service/MediaCleanupPublisher.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/service/MediaCleanupPublisher.java
@@ -1,0 +1,17 @@
+package com.souf.soufwebsite.domain.file.service;
+
+import com.souf.soufwebsite.domain.file.event.MediaCleanupEvent;
+import com.souf.soufwebsite.global.common.PostType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MediaCleanupPublisher {
+    private final ApplicationEventPublisher publisher;
+
+    public void publish(PostType type, Long postId) {
+        publisher.publishEvent(new MediaCleanupEvent(type, postId));
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/file/service/MediaCleanupService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/service/MediaCleanupService.java
@@ -1,0 +1,77 @@
+package com.souf.soufwebsite.domain.file.service;
+
+import com.souf.soufwebsite.domain.file.entity.Media;
+import com.souf.soufwebsite.domain.file.event.MediaCleanupEvent;
+import com.souf.soufwebsite.domain.file.repository.MediaRepository;
+import com.souf.soufwebsite.global.util.S3KeyUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MediaCleanupService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final MediaRepository mediaRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(MediaCleanupEvent e) {
+        // 1) DB에서 해당 포스트의 미디어 가져오기
+        List<Media> medias = mediaRepository.findAllByPostTypeAndPostId(e.postType(), e.postId());
+        if (medias.isEmpty()) return;
+
+        // 2) URL -> Key 변환(원본+썸네일 모두) → SDK v2의 ObjectIdentifier 리스트 생성
+        List<ObjectIdentifier> objects = new ArrayList<>();
+        for (Media m : medias) {
+            addObject(objects, m.getOriginalUrl());
+            addObject(objects, m.getThumbnailUrl()); // 썸네일 필드가 있으면 같이 제거
+            // 파생 사이즈/경로가 더 있다면 여기서 추가
+        }
+
+        // 3) S3 일괄 삭제 (키가 하나라도 있으면)
+        if (!objects.isEmpty()) {
+            Delete delete = Delete.builder()
+                    .objects(objects)
+                    .build();
+
+            DeleteObjectsRequest req = DeleteObjectsRequest.builder()
+                    .bucket(bucket)
+                    .delete(delete)
+                    .build();
+
+            try {
+                s3Client.deleteObjects(req);
+            } catch (S3Exception ex) { // ✅ v2 예외
+                log.warn("S3 deleteObjects failed: {}", ex.awsErrorDetails().errorMessage(), ex);
+                // 정책에 따라 DB 삭제 보류/진행 결정. 보통 DB는 기준으로 두고 진행.
+            }
+        }
+
+        // 4) DB media 레코드 제거
+        mediaRepository.deleteAll(medias);
+    }
+
+    private void addObject(List<ObjectIdentifier> objects, String url) {
+        String key = S3KeyUtils.extractKeyFromUrl(url, bucket); // 정적 유틸 사용 (빈 주입 X)
+        if (key != null && !key.isBlank()) {
+            objects.add(ObjectIdentifier.builder().key(key).build());
+        }
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/domain/file/service/MediaCleanupService.java
+++ b/src/main/java/com/souf/soufwebsite/domain/file/service/MediaCleanupService.java
@@ -42,10 +42,8 @@ public class MediaCleanupService {
 
         // 2) URL -> Key 변환(원본+썸네일 모두) → SDK v2의 ObjectIdentifier 리스트 생성
         List<ObjectIdentifier> objects = new ArrayList<>();
-        for (Media m : medias) {
-            addObject(objects, m.getOriginalUrl());
-            addObject(objects, m.getThumbnailUrl()); // 썸네일 필드가 있으면 같이 제거
-            // 파생 사이즈/경로가 더 있다면 여기서 추가
+        for (Media media : medias) {
+            addAllObjects(objects, media);
         }
 
         // 3) S3 일괄 삭제 (키가 하나라도 있으면)
@@ -71,8 +69,14 @@ public class MediaCleanupService {
         mediaRepository.deleteAllByPostTypeAndPostId(e.postType(), e.postId());
     }
 
-    private void addObject(List<ObjectIdentifier> objects, String url) {
-        String key = S3KeyUtils.extractKeyFromUrl(url, bucket); // 정적 유틸 사용 (빈 주입 X)
+    private void addAllObjects(List<ObjectIdentifier> objects, Media media) {
+        addIfPresent(objects, media.getOriginalUrl());
+        addIfPresent(objects, media.getThumbnailUrl());
+    }
+
+    private void addIfPresent(List<ObjectIdentifier> objects, String url) {
+        if (url == null || url.isBlank()) return;
+        String key = S3KeyUtils.extractKeyFromUrl(url, bucket);
         if (key != null && !key.isBlank()) {
             objects.add(ObjectIdentifier.builder().key(key).build());
         }

--- a/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/souf/soufwebsite/domain/member/entity/Member.java
@@ -6,7 +6,7 @@ import com.souf.soufwebsite.global.common.BaseEntity;
 import com.souf.soufwebsite.global.common.category.dto.CategoryDto;
 import com.souf.soufwebsite.global.common.category.exception.NotDuplicateCategoryException;
 import com.souf.soufwebsite.global.common.category.exception.NotExceedCategoryLimitException;
-import com.souf.soufwebsite.global.util.HashUtil;
+import com.souf.soufwebsite.global.util.HashUtils;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
@@ -146,7 +146,7 @@ public class Member extends BaseEntity {
     }
 
     public void softDelete() { // SHA-256 같은 방식
-        this.email = "deleted:" + HashUtil.sha256(this.email);
+        this.email = "deleted:" + HashUtils.sha256(this.email);
         this.username = "탈퇴한 회원";
         this.intro = "탈퇴한 회원입니다.";
         this.personalUrl = null;

--- a/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/recruit/service/RecruitServiceImpl.java
@@ -11,6 +11,7 @@ import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.domain.file.dto.PresignedUrlResDto;
 import com.souf.soufwebsite.domain.file.entity.Media;
 import com.souf.soufwebsite.domain.file.service.FileService;
+import com.souf.soufwebsite.domain.file.service.MediaCleanupPublisher;
 import com.souf.soufwebsite.domain.member.dto.ReqDto.MemberIdReqDto;
 import com.souf.soufwebsite.domain.member.entity.Member;
 import com.souf.soufwebsite.domain.member.exception.NotFoundMemberException;
@@ -61,6 +62,7 @@ public class RecruitServiceImpl implements RecruitService {
     private final CategoryService categoryService;
     private final RedisUtil redisUtil;
     private final IndexEventPublisherHelper indexEventPublisherHelper;
+    private final MediaCleanupPublisher mediaCleanupPublisher;
     private final SlackService slackService;
     private final ViewCountService viewCountService;
 
@@ -167,6 +169,7 @@ public class RecruitServiceImpl implements RecruitService {
     }
 
     @Override
+    @Transactional
     public void deleteRecruit(String email, Long recruitId) {
         Member member = findIfEmailExists(email);
         Recruit recruit = findIfRecruitExist(recruitId);
@@ -176,6 +179,8 @@ public class RecruitServiceImpl implements RecruitService {
         redisUtil.deleteKey(recruitViewKey);
 
         recruitRepository.delete(recruit);
+
+        mediaCleanupPublisher.publish(PostType.RECRUIT, recruitId);
 
         indexEventPublisherHelper.publishIndexEvent(
                 EntityType.RECRUIT,

--- a/src/main/java/com/souf/soufwebsite/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/souf/soufwebsite/domain/review/service/ReviewServiceImpl.java
@@ -4,6 +4,7 @@ import com.souf.soufwebsite.domain.file.dto.MediaReqDto;
 import com.souf.soufwebsite.domain.file.dto.PresignedUrlResDto;
 import com.souf.soufwebsite.domain.file.entity.Media;
 import com.souf.soufwebsite.domain.file.service.FileService;
+import com.souf.soufwebsite.domain.file.service.MediaCleanupPublisher;
 import com.souf.soufwebsite.domain.member.entity.Member;
 import com.souf.soufwebsite.domain.member.exception.NotFoundMemberException;
 import com.souf.soufwebsite.domain.member.repository.MemberRepository;
@@ -39,6 +40,8 @@ public class ReviewServiceImpl implements ReviewService {
 
     private final FileService fileService;
     private final ViewCountService viewCountService;
+
+    private final MediaCleanupPublisher mediaCleanupPublisher;
 
 
     private Member getCurrentMember() {
@@ -113,6 +116,7 @@ public class ReviewServiceImpl implements ReviewService {
         return new ReviewCreatedResDto(review.getId(), presignedUrlResDtos);
     }
 
+    @Transactional
     @Override
     public void deleteReview(String email, Long reviewId) {
         Member currentMember = findIfMemberExists(email);
@@ -120,6 +124,8 @@ public class ReviewServiceImpl implements ReviewService {
         verifyIfReviewIsMine(review, currentMember);
 
         reviewRepository.delete(review);
+
+        mediaCleanupPublisher.publish(PostType.REVIEW, reviewId);
     }
 
     private void verifyIfReviewIsMine(Review review, Member member) {

--- a/src/main/java/com/souf/soufwebsite/global/common/mail/SesMailService.java
+++ b/src/main/java/com/souf/soufwebsite/global/common/mail/SesMailService.java
@@ -2,7 +2,7 @@ package com.souf.soufwebsite.global.common.mail;
 
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.model.SendTemplatedEmailRequest;
-import com.souf.soufwebsite.global.util.SesTemplateUtil;
+import com.souf.soufwebsite.global.util.SesTemplateUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class SesMailService {
 
-    private final SesTemplateUtil templateUtil;
+    private final SesTemplateUtils templateUtil;
     private final AmazonSimpleEmailService emailService;
 
     public void sendEmailAuthenticationCode(String to, String purpose, String authenticationCode) {

--- a/src/main/java/com/souf/soufwebsite/global/util/HashUtils.java
+++ b/src/main/java/com/souf/soufwebsite/global/util/HashUtils.java
@@ -5,7 +5,7 @@ import com.souf.soufwebsite.global.exception.hash.NotAvailableAlgorithmException
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-public class HashUtil {
+public class HashUtils {
 
     public static String sha256(String input) {
         try {

--- a/src/main/java/com/souf/soufwebsite/global/util/S3KeyUtils.java
+++ b/src/main/java/com/souf/soufwebsite/global/util/S3KeyUtils.java
@@ -1,0 +1,45 @@
+package com.souf.soufwebsite.global.util;
+
+import java.net.URI;
+
+public final class S3KeyUtils {
+    private S3KeyUtils() {}
+
+    public static String extractKeyFromUrl (String urlOrKey, String bucket) {
+        if (urlOrKey == null || urlOrKey.isBlank()) return null;
+
+        if (!urlOrKey.startsWith("http://") && !urlOrKey.startsWith("https://")) {
+            return stripLeadingSlash(urlOrKey);
+        }
+
+        try {
+            URI u = new URI(urlOrKey);
+            String host = u.getHost();
+            String path = u.getPath();
+            if (host == null || path == null) return null;
+
+            // 가상호스트 스타일: <bucket>.s3.<region>.amazonaws.com/<key>
+            if (host.startsWith(bucket + ".")) {
+                return stripLeadingSlash(path);
+            }
+
+            // 경로 스타일: s3.<region>.amazonaws.com/<bucket>/<key>
+            if (host.contains("amazonaws.com")) {
+                String p = stripLeadingSlash(path);
+                if (p.startsWith(bucket + "/")) {
+                    return p.substring(bucket.length() + 1);
+                }
+                return p; // 혹시 버킷 생략된 커스텀 라우팅인 경우
+            }
+
+            // CloudFront / 커스텀 도메인: path 전체를 key로 사용
+            return stripLeadingSlash(path);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String stripLeadingSlash(String s) {
+        return (s != null && s.startsWith("/")) ? s.substring(1) : s;
+    }
+}

--- a/src/main/java/com/souf/soufwebsite/global/util/SesTemplateUtils.java
+++ b/src/main/java/com/souf/soufwebsite/global/util/SesTemplateUtils.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 
 @Component
-public class SesTemplateUtil {
+public class SesTemplateUtils {
 
     @Value("${spring.mail.username}")
     private String mail;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
       port: 6379
       ssl:
         enabled: false
-      host: redis-container
+      host: localhost
 
   jpa:
     hibernate:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
       port: 6379
       ssl:
         enabled: false
-      host: localhost
+      host: redis-container
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 개요
RECRUIT, FEED, COMMENT, REVIEW 의 게시물들에서 파일 첨부가 가능함
이 게시물들의 삭제 시 S3에서도 파일을 함께 삭제

## 진행한 이슈
- close #238 

## 구현 내용
- [x] eventPublisher 작성
- [x] delete 트랜잭션이 실행된 이후에 이벤트를 발생시켜 s3 의 파일 삭제 실행

## 참고 자료
- 구현 내용을 설명하기에 추가적인 내용이 필요할 시 기입해주세요.
